### PR TITLE
[feature] 링크 저장씬 새 폴더 추가 연결 및 짜잘 기능 추가

### DIFF
--- a/app/src/main/java/com/mashup/dorabangs/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/mashup/dorabangs/navigation/MainNavHost.kt
@@ -72,8 +72,7 @@ fun MainNavHost(
                 appState.navController.popBackStack()
             },
             onClickSaveButton = {
-                // TODO 다하고 저장누르면 서버에 정보 날리고 홈으로 이동
-                // TODO 클릭 때 데이터 스토어에 저장해서 다시 클립보드 안뜨게 하기
+                // TODO 클릭 때 데이터 스토어에 저장해서 다시 클립보드 안뜨게 하기?
                 appState.navController.navigateToHome(
                     navOptions = navOptions {
                         popUpTo(appState.navController.graph.id) {
@@ -81,6 +80,9 @@ fun MainNavHost(
                         }
                     },
                 )
+            },
+            onClickAddNewFolder = {
+                appState.navController.navigateToHomeCrateFolder()
             },
         )
     }

--- a/feature/save/src/main/java/com/dorabangs/feature/navigation/SaveLinkSelectFolderNavigation.kt
+++ b/feature/save/src/main/java/com/dorabangs/feature/navigation/SaveLinkSelectFolderNavigation.kt
@@ -23,6 +23,7 @@ fun NavController.navigateToSaveLinkSelectFolder(
 fun NavGraphBuilder.saveLinkSelectFolder(
     onClickBackButton: () -> Unit,
     onClickSaveButton: () -> Unit,
+    onClickAddNewFolder: () -> Unit,
 ) {
     composable(
         route = "${NavigationRoute.SaveLink.SelectFolder.route}/{copiedUrl}",
@@ -37,6 +38,7 @@ fun NavGraphBuilder.saveLinkSelectFolder(
             modifier = Modifier,
             onClickSaveButton = onClickSaveButton,
             onClickBackIcon = onClickBackButton,
+            onClickAddNewFolder = onClickAddNewFolder,
         )
     }
 }

--- a/feature/save/src/main/java/com/dorabangs/feature/save/DoraSaveViewModel.kt
+++ b/feature/save/src/main/java/com/dorabangs/feature/save/DoraSaveViewModel.kt
@@ -33,7 +33,7 @@ class DoraSaveViewModel @Inject constructor(
 
     private fun getFolderList() = viewModelScope.doraLaunch {
         val list = getFolderListUseCase.invoke()
-        val newList = (list.defaultFolders + list.customFolders).let { mergedList ->
+        val newList = (list.defaultFolders.reversed() + list.customFolders).let { mergedList ->
             mergedList.mapIndexed { index, item ->
                 SelectableFolder(
                     id = item.id,

--- a/feature/save/src/main/java/com/dorabangs/feature/save/DoraSaveViewModel.kt
+++ b/feature/save/src/main/java/com/dorabangs/feature/save/DoraSaveViewModel.kt
@@ -9,13 +9,13 @@ import com.mashup.dorabangs.domain.usecase.folder.GetFolderListUseCase
 import com.mashup.dorabangs.domain.usecase.posts.SaveLinkUseCase
 import com.mashup.dorabangs.domain.usecase.save.DoraUrlCheckUseCase
 import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 import org.orbitmvi.orbit.Container
 import org.orbitmvi.orbit.ContainerHost
 import org.orbitmvi.orbit.syntax.simple.intent
 import org.orbitmvi.orbit.syntax.simple.postSideEffect
 import org.orbitmvi.orbit.syntax.simple.reduce
 import org.orbitmvi.orbit.viewmodel.container
-import javax.inject.Inject
 
 @HiltViewModel
 class DoraSaveViewModel @Inject constructor(
@@ -33,6 +33,16 @@ class DoraSaveViewModel @Inject constructor(
 
     private fun getFolderList() = viewModelScope.doraLaunch {
         val list = getFolderListUseCase.invoke()
+        val firstItem = listOf(
+            SelectableFolder(
+                id = null,
+                name = "새 폴더 추가",
+                type = "",
+                createdAt = null,
+                postCount = null,
+                isSelected = false
+            )
+        )
         val newList = (list.defaultFolders.reversed() + list.customFolders).let { mergedList ->
             mergedList.mapIndexed { index, item ->
                 SelectableFolder(
@@ -48,7 +58,7 @@ class DoraSaveViewModel @Inject constructor(
         intent {
             reduce {
                 state.copy(
-                    folderList = newList,
+                    folderList = firstItem + newList,
                 )
             }
         }
@@ -78,16 +88,23 @@ class DoraSaveViewModel @Inject constructor(
         )
     }
 
+    /**
+     * 0번 째 있는 새 폴더 추가는 클릭이 안됨
+     */
     fun updateSelectedFolder(index: Int) = intent {
         reduce {
-            state.folderList.mapIndexed { listIndex, item ->
-                if (listIndex == index - 1) {
-                    item.copy(isSelected = true)
-                } else item.copy(isSelected = false)
-            }.let { newList ->
-                state.copy(
-                    folderList = newList,
-                )
+            if (index != 0){
+                state.folderList.mapIndexed { listIndex, item ->
+                    if (listIndex == index) {
+                        item.copy(isSelected = true)
+                    } else item.copy(isSelected = false)
+                }.let { newList ->
+                    state.copy(
+                        folderList = newList,
+                    )
+                }
+            } else {
+                state
             }
         }
     }

--- a/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveScreen.kt
+++ b/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveScreen.kt
@@ -46,7 +46,7 @@ fun DoraLinkSaveScreen(
                 .padding(horizontal = 20.dp),
         ) {
             DoraTextField(
-                text = "",
+                text = state.urlLink,
                 hintText = stringResource(id = R.string.link_save_hint_text),
                 labelText = stringResource(id = R.string.link_save_label_text),
                 helperText = stringResource(id = R.string.link_save_error_text),

--- a/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveSelectFolderRoute.kt
+++ b/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveSelectFolderRoute.kt
@@ -13,6 +13,7 @@ import org.orbitmvi.orbit.compose.collectSideEffect
 fun DoraLinkSaveSelectFolderRoute(
     onClickBackIcon: () -> Unit,
     onClickSaveButton: () -> Unit,
+    onClickAddNewFolder: () -> Unit,
     modifier: Modifier = Modifier,
     viewModel: DoraSaveViewModel = hiltViewModel(),
 ) {
@@ -20,7 +21,13 @@ fun DoraLinkSaveSelectFolderRoute(
     if (state.isError) { onClickBackIcon.invoke() }
     viewModel.collectSideEffect { sideEffect ->
         when (sideEffect) {
-            is DoraSaveSideEffect.ClickItem -> viewModel.updateSelectedFolder(index = sideEffect.index)
+            is DoraSaveSideEffect.ClickItem -> {
+                if (sideEffect.index == 0) {
+                    onClickAddNewFolder()
+                } else {
+                    viewModel.updateSelectedFolder(index = sideEffect.index)
+                }
+            }
             is DoraSaveSideEffect.ClickSaveButton -> viewModel.saveLink(id = sideEffect.id)
         }
     }
@@ -34,5 +41,6 @@ fun DoraLinkSaveSelectFolderRoute(
         },
         onClickBackIcon = onClickBackIcon,
         onClickItem = viewModel::clickSelectableItem,
+        getInitialFolder = viewModel::getFolderList,
     )
 }

--- a/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveSelectFolderScreen.kt
+++ b/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveSelectFolderScreen.kt
@@ -9,10 +9,15 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LifecycleStartEffect
+import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.dorabangs.feature.save.DoraSaveState
 import com.dorabangs.feature.save.R
 import com.dorabangs.feature.save.SelectableFolder
@@ -30,8 +35,27 @@ fun DoraLinkSaveSelectFolderScreen(
     onClickBackIcon: () -> Unit,
     onClickSaveButton: () -> Unit,
     onClickItem: (Int) -> Unit,
+    getInitialFolder: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
+    val lifecycleOwner = LocalLifecycleOwner.current
+    val lifecycleState = lifecycleOwner.lifecycle.currentStateFlow.collectAsState()
+    LaunchedEffect(key1 = lifecycleState) {
+        when (lifecycleState.value) {
+            Lifecycle.State.DESTROYED -> println("tjrwn current state is DESTROY")
+            Lifecycle.State.INITIALIZED -> println("tjrwn current state is INITIALIZED")
+            Lifecycle.State.CREATED -> println("tjrwn current state is CRETED")
+            Lifecycle.State.STARTED -> println("tjrwn current state is STARTED")
+            Lifecycle.State.RESUMED -> println("tjrwn current state is RESUMED")
+        }
+    }
+    LifecycleStartEffect(key1 = Unit) {
+        getInitialFolder()
+        onStopOrDispose {
+            /* no-op */
+        }
+    }
+
     Column(
         modifier = modifier
             .fillMaxSize()
@@ -86,5 +110,6 @@ fun DoraLinkSaveSelectFolderScreenPreview() {
         onClickBackIcon = {},
         onClickSaveButton = {},
         onClickItem = {},
+        getInitialFolder = {},
     )
 }

--- a/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveSelectFolderScreen.kt
+++ b/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveSelectFolderScreen.kt
@@ -10,14 +10,10 @@ import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.lifecycle.Lifecycle
-import androidx.lifecycle.compose.LifecycleStartEffect
-import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.dorabangs.feature.save.DoraSaveState
 import com.dorabangs.feature.save.R
 import com.dorabangs.feature.save.SelectableFolder
@@ -38,22 +34,8 @@ fun DoraLinkSaveSelectFolderScreen(
     getInitialFolder: () -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val lifecycleOwner = LocalLifecycleOwner.current
-    val lifecycleState = lifecycleOwner.lifecycle.currentStateFlow.collectAsState()
-    LaunchedEffect(key1 = lifecycleState) {
-        when (lifecycleState.value) {
-            Lifecycle.State.DESTROYED -> println("tjrwn current state is DESTROY")
-            Lifecycle.State.INITIALIZED -> println("tjrwn current state is INITIALIZED")
-            Lifecycle.State.CREATED -> println("tjrwn current state is CRETED")
-            Lifecycle.State.STARTED -> println("tjrwn current state is STARTED")
-            Lifecycle.State.RESUMED -> println("tjrwn current state is RESUMED")
-        }
-    }
-    LifecycleStartEffect(key1 = Unit) {
+    LaunchedEffect(key1 = Unit) {
         getInitialFolder()
-        onStopOrDispose {
-            /* no-op */
-        }
     }
 
     Column(

--- a/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveSelectFolderScreen.kt
+++ b/feature/save/src/main/java/com/dorabangs/feature/save/screen/DoraLinkSaveSelectFolderScreen.kt
@@ -51,13 +51,7 @@ fun DoraLinkSaveSelectFolderScreen(
             DoraSelectableFolderListItems(
                 modifier = Modifier
                     .verticalScroll(state = rememberScrollState()),
-                items = listOf(
-                    DoraSelectableFolderItem(
-                        itemName = stringResource(id = R.string.link_save_add_new_folder),
-                        isSelected = false,
-                        vector = NewFolder.IcNewFolder,
-                    ),
-                ) + state.folderList.toSelectableItems(),
+                items = state.folderList.toSelectableItems(),
                 onClickItem = onClickItem,
             )
         }


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약

- 피그마 보고 default 폴더중에서 보여줘야 할것만 보여줌
- 뷰쪽에서 0번째 아이템(새 폴더 추가) 추가해주던거 그냥 initFolder할떄 같이 해줌
- 새폴더 연결 씬 그냥 재활용했음다 (별 로직 없어서)

로직을 살짝 수정해서 (LaunchedEffect로) 영상보다는 목록이 좀 더 빨리 나올거임

## 작업 내용
> 실제 작업 내용

## 시연 화면 (option)
> 실행 스크린샷 혹은 영상 첨부

https://github.com/user-attachments/assets/1b70656d-a800-4524-a01e-5632edaf54d1
