### PR TITLE
[refactoring] http 막기, https://로 시작 안하는거 붙여주기 추가

### DIFF
--- a/data/src/main/AndroidManifest.xml
+++ b/data/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest>
 
-    <application android:usesCleartextTraffic="true" />
 </manifest>

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/DoraUrlCheckRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/DoraUrlCheckRemoteDataSourceImpl.kt
@@ -14,14 +14,17 @@ class DoraUrlCheckRemoteDataSourceImpl @Inject constructor() : DoraUrlCheckRemot
     }
 
     /**
-     * 전달 받은 url을 체크합니다.
+     * 전달 받은 url을 체크합니다. https://로 시작하지 않으면 변환해줍니다 (www.naver.com -> https://www.naver.com)
+     * http로만 시작하는 경우 통신을 막아둬서 어차피 fail
      * 리다이렉션이 있는 경우, 특히나 short Link 의 경우 헤더의 Location 값이 원 주소이기 때문에 검사합니다
      * 추가로 short Link 에서는 원 링크가 아닌 이상 title, thumbnail 을 가져올 수 없어서,
      * connection을 원 주소로 다시 연결하여 정보를 가져옴
      */
     private suspend fun checkUrl(urlLink: String): DoraUrlCheckResponse = withContext(Dispatchers.IO) {
+        val validUrlLink =
+            if (urlLink.startsWith("https://").not()) "https://${urlLink}" else urlLink
         return@withContext runCatching {
-            var connection = Jsoup.connect(urlLink)
+            var connection = Jsoup.connect(validUrlLink)
                 .followRedirects(false)
                 .ignoreContentType(true)
 
@@ -45,7 +48,7 @@ class DoraUrlCheckRemoteDataSourceImpl @Inject constructor() : DoraUrlCheckRemot
             val thumbnailUrl = thumbnailElement?.attr("content")
 
             DoraUrlCheckResponse(
-                urlLink = longUrlLink ?: urlLink,
+                urlLink = longUrlLink ?: validUrlLink,
                 title = title.orEmpty(),
                 thumbnailUrl = thumbnailUrl.orEmpty(),
                 isShortLink = longUrlLink == null,

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/DoraUrlCheckRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/DoraUrlCheckRemoteDataSourceImpl.kt
@@ -22,7 +22,7 @@ class DoraUrlCheckRemoteDataSourceImpl @Inject constructor() : DoraUrlCheckRemot
      */
     private suspend fun checkUrl(urlLink: String): DoraUrlCheckResponse = withContext(Dispatchers.IO) {
         val validUrlLink =
-            if (urlLink.startsWith("https://").not()) "https://${urlLink}" else urlLink
+            if (urlLink.startsWith("https://").not()) "https://$urlLink" else urlLink
         return@withContext runCatching {
             var connection = Jsoup.connect(validUrlLink)
                 .followRedirects(false)

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeDoraSnackBar.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeDoraSnackBar.kt
@@ -49,3 +49,13 @@ fun HomeDoraSnackBar(
         dismissAction = { dismissAction(text) },
     )
 }
+
+// 1. https://www.naver.com -> 잘 입력했을 때 그대로
+// 2. http://www.naver.com -> http로 입력했을 때
+// 3. www.naver.com -> 아무것도 없이 들어왔을 때
+fun String.checkAndReplacePrefix(): String {
+    if (startsWith("https")) return this
+    if (startsWith("http")) return this
+    if (contains("https").not() && contains("http").not()) return "https://${this}"
+    return ""
+}

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeDoraSnackBar.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeDoraSnackBar.kt
@@ -49,13 +49,3 @@ fun HomeDoraSnackBar(
         dismissAction = { dismissAction(text) },
     )
 }
-
-// 1. https://www.naver.com -> 잘 입력했을 때 그대로
-// 2. http://www.naver.com -> http로 입력했을 때
-// 3. www.naver.com -> 아무것도 없이 들어왔을 때
-fun String.checkAndReplacePrefix(): String {
-    if (startsWith("https")) return this
-    if (startsWith("http")) return this
-    if (contains("https").not() && contains("http").not()) return "https://${this}"
-    return ""
-}


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약

제목과 동일.

## 작업 내용
> 실제 작업 내용

http 로 시작하는 url 실패하게 수정(어차피 실패지만, checkUrl에서 https://http://www.naver.com 으로 바뀌긴함 . ㅋㅋ)
https 없으면 붙여줌 ex) www.naver.com => https://www.naver.com

## 시연 화면 (option)
> 실행 스크린샷 혹은 영상 첨부

![image](https://github.com/user-attachments/assets/413a855a-7f16-46c1-8468-97f2d8ed8b0e)

![image](https://github.com/user-attachments/assets/e3960ab8-e8c1-4fdf-9f22-4e41f3ed8e7e)

![image](https://github.com/user-attachments/assets/ee0857e9-18f3-4269-8cc0-aa7aae4bf6cc)


## To Reviers
> 리뷰어들에게 전할 말

## Close
close #