### PR TITLE
바텀시트 수정 및 API 연결

### DIFF
--- a/app/src/main/java/com/mashup/dorabangs/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/mashup/dorabangs/navigation/MainNavHost.kt
@@ -50,7 +50,11 @@ fun MainNavHost(
         )
         homeCreateFolderNavigation(
             navController = appState.navController,
-            onClickBackIcon = { appState.navController.popBackStack() },
+            onClickBackIcon = {
+                appState.navController.navigateToHome(
+                    isVisibleMovingBottomSheet = true,
+                )
+            },
             navigateToHome = { appState.navController.popBackStack() },
             navigateToHomeAfterSaveLink = {
                 appState.navController.navigateToHome(

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetItemUIModel.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetItemUIModel.kt
@@ -14,4 +14,5 @@ data class SelectableBottomSheetItemUIModel(
     @DrawableRes val icon: Int,
     val itemName: String,
     val isSelected: Boolean,
+    val color: Color = DoraColorTokens.Black,
 )

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetItemUIModel.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetItemUIModel.kt
@@ -12,6 +12,7 @@ data class BottomSheetItemUIModel(
 
 data class SelectableBottomSheetItemUIModel(
     @DrawableRes val icon: Int,
+    val id: String = "",
     val itemName: String,
     val isSelected: Boolean,
     val color: Color = DoraColorTokens.Black,

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
@@ -102,6 +102,7 @@ object DoraBottomSheet : BottomSheetType {
                                 color = DoraColorTokens.Primary,
                             ),
                             onClickItem = onClickCreateFolder,
+                            isLastItem = false,
                         )
                     }
 
@@ -110,6 +111,7 @@ object DoraBottomSheet : BottomSheetType {
                             modifier = Modifier.fillMaxWidth(),
                             data = folderList[index],
                             onClickItem = onClickMoveFolder,
+                            isLastItem = index == folderList.lastIndex,
                         )
                     }
 

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
@@ -69,10 +69,12 @@ object DoraBottomSheet : BottomSheetType {
     override fun MovingFolderBottomSheet(
         modifier: Modifier,
         isShowSheet: Boolean,
+        btnEnable: Boolean,
         folderList: List<SelectableBottomSheetItemUIModel>,
         onDismissRequest: () -> Unit,
         onClickCreateFolder: () -> Unit,
-        onClickMoveFolder: () -> Unit,
+        onClickMoveFolder: (String) -> Unit,
+        onClickCompleteButton: () -> Unit,
     ) {
         if (isShowSheet) {
             DoraBaseBottomSheet(
@@ -81,7 +83,7 @@ object DoraBottomSheet : BottomSheetType {
                 onDismissRequest = onDismissRequest,
             ) {
                 LazyColumn(
-                    modifier = Modifier.padding(bottom = 50.dp)
+                    modifier = Modifier.padding(bottom = 50.dp),
                 ) {
                     item {
                         Text(
@@ -112,7 +114,7 @@ object DoraBottomSheet : BottomSheetType {
                         DoraBottomSheetFolderItem(
                             modifier = Modifier.fillMaxWidth(),
                             data = folderList[index],
-                            onClickItem = onClickMoveFolder,
+                            onClickItem = { onClickMoveFolder(folderList[index].id) },
                             isLastItem = index == folderList.lastIndex,
                         )
                     }
@@ -123,8 +125,8 @@ object DoraBottomSheet : BottomSheetType {
                                 .fillMaxWidth()
                                 .padding(horizontal = 20.dp, vertical = 16.dp),
                             buttonText = stringResource(id = R.string.moving_folder_bottom_sheet_complete),
-                            enabled = true,
-                            onClickButton = onDismissRequest,
+                            enabled = btnEnable,
+                            onClickButton = onClickCompleteButton,
                         )
                     }
                 }
@@ -150,10 +152,12 @@ sealed interface BottomSheetType {
     fun MovingFolderBottomSheet(
         modifier: Modifier,
         isShowSheet: Boolean,
+        btnEnable: Boolean,
         folderList: List<SelectableBottomSheetItemUIModel>,
         onDismissRequest: () -> Unit,
         onClickCreateFolder: () -> Unit,
-        onClickMoveFolder: () -> Unit,
+        onClickMoveFolder: (String) -> Unit,
+        onClickCompleteButton: () -> Unit,
     )
 }
 

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
@@ -80,7 +80,9 @@ object DoraBottomSheet : BottomSheetType {
                 containerColor = BottomSheetColorTokens.MovingFolderColor,
                 onDismissRequest = onDismissRequest,
             ) {
-                LazyColumn {
+                LazyColumn(
+                    modifier = Modifier.padding(bottom = 50.dp)
+                ) {
                     item {
                         Text(
                             modifier = Modifier

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
@@ -1,12 +1,19 @@
 package com.mashup.dorabangs.core.designsystem.component.bottomsheet
 
 import androidx.annotation.StringRes
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
@@ -20,6 +27,7 @@ import com.mashup.dorabangs.core.designsystem.theme.DoraTypoTokens
 
 object DoraBottomSheet : BottomSheetType {
 
+    @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun MoreButtonBottomSheet(
         modifier: Modifier,
@@ -65,6 +73,7 @@ object DoraBottomSheet : BottomSheetType {
         }
     }
 
+    @OptIn(ExperimentalMaterial3Api::class)
     @Composable
     override fun MovingFolderBottomSheet(
         modifier: Modifier,
@@ -76,15 +85,21 @@ object DoraBottomSheet : BottomSheetType {
         onClickMoveFolder: (String) -> Unit,
         onClickCompleteButton: () -> Unit,
     ) {
+        val state = rememberModalBottomSheetState(skipPartiallyExpanded = false)
+        var sheetHeight by remember { mutableFloatStateOf(0.4f) }
+        LaunchedEffect(state.currentValue) {
+            if (state.currentValue == SheetValue.Expanded) {
+                sheetHeight = 0.8f
+            }
+        }
         if (isShowSheet) {
             DoraBaseBottomSheet(
-                modifier = modifier,
+                state = state,
+                modifier = modifier.fillMaxHeight(sheetHeight),
                 containerColor = BottomSheetColorTokens.MovingFolderColor,
                 onDismissRequest = onDismissRequest,
             ) {
-                LazyColumn(
-                    modifier = Modifier.padding(bottom = 50.dp),
-                ) {
+                LazyColumn {
                     item {
                         Text(
                             modifier = Modifier

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
@@ -6,6 +6,8 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -41,12 +43,12 @@ object DoraBottomSheet : BottomSheetType {
                         .padding(top = 46.dp),
                     items = listOf(
                         BottomSheetItemUIModel(
-                            icon = R.drawable.ic_plus,
+                            icon = R.drawable.ic_trashbin,
                             itemName = stringResource(id = firstItemName),
                             color = DoraColorTokens.Alert,
                         ),
                         BottomSheetItemUIModel(
-                            icon = R.drawable.ic_plus,
+                            icon = R.drawable.ic_edit,
                             itemName = stringResource(id = secondItemName),
                         ),
                     ),
@@ -94,9 +96,10 @@ object DoraBottomSheet : BottomSheetType {
                         DoraBottomSheetFolderItem(
                             modifier = Modifier.fillMaxWidth(),
                             data = SelectableBottomSheetItemUIModel(
-                                icon = R.drawable.ic_plus,
+                                icon = R.drawable.ic_add_folder_purple,
                                 itemName = stringResource(id = R.string.moving_folder_dialog_add_folder),
                                 isSelected = false,
+                                color = DoraColorTokens.Primary,
                             ),
                             onClickItem = onClickCreateFolder,
                         )
@@ -148,4 +151,9 @@ sealed interface BottomSheetType {
         onClickCreateFolder: () -> Unit,
         onClickMoveFolder: () -> Unit,
     )
+}
+
+enum class ExpandedType {
+    MIN,
+    MAX,
 }

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/DoraBottomSheet.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/DoraBottomSheet.kt
@@ -3,11 +3,14 @@ package com.mashup.dorabangs.core.designsystem.component.bottomsheet
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -18,16 +21,19 @@ import com.mashup.dorabangs.core.designsystem.theme.DoraRoundTokens
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DoraBaseBottomSheet(
+    state: SheetState = rememberModalBottomSheetState(),
     modifier: Modifier = Modifier,
     containerColor: Color = BottomSheetColorTokens.MoreViewBackgroundColor,
     onDismissRequest: () -> Unit,
     content: @Composable ColumnScope.() -> Unit,
 ) {
     ModalBottomSheet(
+        sheetState = state,
         modifier = modifier,
         containerColor = containerColor,
-        shape = DoraRoundTokens.Round16,
+        shape = DoraRoundTokens.TopRound16,
         dragHandle = { DoraDragHandle(Modifier.padding(top = 6.dp)) },
+        windowInsets = WindowInsets(bottom = 48.dp),
         onDismissRequest = onDismissRequest,
     ) {
         content()

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/DoraBottomSheetItem.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/DoraBottomSheetItem.kt
@@ -101,6 +101,7 @@ fun DoraBottomSheetFolderItem(
         Row(
             modifier = modifier
                 .background(background)
+                .clickable { onClickItem() }
                 .padding(vertical = 14.dp, horizontal = 16.dp),
             horizontalArrangement = Arrangement.SpaceBetween,
             verticalAlignment = Alignment.CenterVertically,
@@ -111,7 +112,6 @@ fun DoraBottomSheetFolderItem(
                     itemName = data.itemName,
                     color = data.color,
                 ),
-                modifier = Modifier.clickable { onClickItem() },
             )
             if (data.isSelected) {
                 Image(

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/DoraBottomSheetItem.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/DoraBottomSheetItem.kt
@@ -77,6 +77,7 @@ fun DoraFolderListItem(
     ) {
         Image(
             painterResource(id = data.icon),
+            modifier = Modifier.size(24.dp),
             contentDescription = "",
         )
         Text(
@@ -91,32 +92,44 @@ fun DoraFolderListItem(
 @Composable
 fun DoraBottomSheetFolderItem(
     data: SelectableBottomSheetItemUIModel,
+    isLastItem: Boolean,
     modifier: Modifier = Modifier,
     background: Color = BottomSheetColorTokens.MovingFolderColor,
     onClickItem: () -> Unit = {},
 ) {
-    Row(
-        modifier = modifier
-            .background(background)
-            .padding(vertical = 14.dp, horizontal = 16.dp),
-        horizontalArrangement = Arrangement.SpaceBetween,
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        DoraFolderListItem(
-            data = BottomSheetItemUIModel(
-                icon = data.icon,
-                itemName = data.itemName,
-                color = data.color,
-            ),
-            modifier = Modifier.clickable { onClickItem() },
-        )
-        if (data.isSelected) {
-            Image(
-                painter = painterResource(id = R.drawable.ic_check),
-                contentDescription = "selectedIcon",
+    Column {
+        Row(
+            modifier = modifier
+                .background(background)
+                .padding(vertical = 14.dp, horizontal = 16.dp),
+            horizontalArrangement = Arrangement.SpaceBetween,
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            DoraFolderListItem(
+                data = BottomSheetItemUIModel(
+                    icon = data.icon,
+                    itemName = data.itemName,
+                    color = data.color,
+                ),
+                modifier = Modifier.clickable { onClickItem() },
             )
-        } else {
-            Box(modifier = Modifier.size(24.dp))
+            if (data.isSelected) {
+                Image(
+                    painter = painterResource(id = R.drawable.ic_check),
+                    contentDescription = "selectedIcon",
+                )
+            } else {
+                Box(modifier = Modifier.size(24.dp))
+            }
+        }
+        if (!isLastItem) {
+            HorizontalDivider(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 16.dp),
+                thickness = 0.5.dp,
+                color = BottomSheetColorTokens.DividerColor,
+            )
         }
     }
 }
@@ -143,5 +156,6 @@ fun PreviewDoraFolderListItem() {
             itemName = "폴더이름",
             isSelected = true,
         ),
+        isLastItem = false,
     )
 }

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/DoraBottomSheetItem.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/DoraBottomSheetItem.kt
@@ -1,5 +1,6 @@
 package com.mashup.dorabangs.core.designsystem.component.bottomsheet
 
+import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -10,7 +11,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -75,7 +75,7 @@ fun DoraFolderListItem(
         modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
     ) {
-        Icon(
+        Image(
             painterResource(id = data.icon),
             contentDescription = "",
         )
@@ -106,13 +106,14 @@ fun DoraBottomSheetFolderItem(
             data = BottomSheetItemUIModel(
                 icon = data.icon,
                 itemName = data.itemName,
+                color = data.color,
             ),
             modifier = Modifier.clickable { onClickItem() },
         )
         if (data.isSelected) {
-            Icon(
-                painter = painterResource(id = R.drawable.ic_plus),
-                contentDescription = "",
+            Image(
+                painter = painterResource(id = R.drawable.ic_check),
+                contentDescription = "selectedIcon",
             )
         } else {
             Box(modifier = Modifier.size(24.dp))

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
@@ -283,7 +283,7 @@ private fun PreviewFeedCard() {
             category = "디자인",
             createdAt = "2024-07-18T15:50:36.181Z",
             thumbnail = "",
-            folderId = ""
+            folderId = "",
         )
     FeedCard(cardInfo = cardInfo)
 }
@@ -301,7 +301,7 @@ private fun PreviewLoadingFeedCard() {
             createdAt = "2024-07-18T15:50:36.181Z",
             thumbnail = "",
             isLoading = true,
-            folderId = ""
+            folderId = "",
         )
     FeedCard(cardInfo = cardInfo)
 }

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
@@ -282,6 +282,7 @@ private fun PreviewFeedCard() {
             category = "디자인",
             createdAt = "2024-07-18T15:50:36.181Z",
             thumbnail = "",
+            folderId = ""
         )
     FeedCard(cardInfo = cardInfo)
 }
@@ -299,6 +300,7 @@ private fun PreviewLoadingFeedCard() {
             createdAt = "2024-07-18T15:50:36.181Z",
             thumbnail = "",
             isLoading = true,
+            folderId = ""
         )
     FeedCard(cardInfo = cardInfo)
 }

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCardUiModel.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCardUiModel.kt
@@ -26,7 +26,7 @@ data class FeedCardUiModel(
                     category = "디자인",
                     createdAt = "2024-07-18T15:50:36.181Z",
                     thumbnail = "",
-                    folderId = ""
+                    folderId = "",
                 ),
                 FeedCardUiModel(
                     id = "",
@@ -36,7 +36,7 @@ data class FeedCardUiModel(
                     category = "디자인",
                     createdAt = "2024-07-18T15:50:36.181Z",
                     thumbnail = "",
-                    folderId = ""
+                    folderId = "",
                 ),
                 FeedCardUiModel(
                     id = "",
@@ -46,7 +46,7 @@ data class FeedCardUiModel(
                     category = "디자인",
                     createdAt = "2024-07-18T15:50:36.181Z",
                     thumbnail = "",
-                    folderId = ""
+                    folderId = "",
                 ),
             )
         }

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCardUiModel.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCardUiModel.kt
@@ -5,6 +5,7 @@ import java.time.temporal.ChronoUnit
 
 data class FeedCardUiModel(
     val id: String,
+    val folderId: String,
     val title: String?,
     val content: String?,
     val category: String? = "",
@@ -25,6 +26,7 @@ data class FeedCardUiModel(
                     category = "디자인",
                     createdAt = "2024-07-18T15:50:36.181Z",
                     thumbnail = "",
+                    folderId = ""
                 ),
                 FeedCardUiModel(
                     id = "",
@@ -34,6 +36,7 @@ data class FeedCardUiModel(
                     category = "디자인",
                     createdAt = "2024-07-18T15:50:36.181Z",
                     thumbnail = "",
+                    folderId = ""
                 ),
                 FeedCardUiModel(
                     id = "",
@@ -43,6 +46,7 @@ data class FeedCardUiModel(
                     category = "디자인",
                     createdAt = "2024-07-18T15:50:36.181Z",
                     thumbnail = "",
+                    folderId = ""
                 ),
             )
         }

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/theme/Radius.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/theme/Radius.kt
@@ -9,6 +9,7 @@ object DoraRoundTokens {
     val Round16 = RoundedCornerShape(16.dp)
     val Round12 = RoundedCornerShape(12.dp)
     val TopRound12 = RoundedCornerShape(topStart = 12.dp, topEnd = 12.dp)
+    val TopRound16 = RoundedCornerShape(topStart = 16.dp, topEnd = 16.dp)
     val BottomRound12 = RoundedCornerShape(bottomStart = 12.dp, bottomEnd = 12.dp)
     val Round8 = RoundedCornerShape(8.dp)
     val Round4 = RoundedCornerShape(4.dp)

--- a/core/designsystem/src/main/res/drawable/ic_add_folder_purple.xml
+++ b/core/designsystem/src/main/res/drawable/ic_add_folder_purple.xml
@@ -1,0 +1,26 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="22dp"
+    android:height="22dp"
+    android:viewportWidth="22"
+    android:viewportHeight="22">
+  <path
+      android:pathData="M11,7.328V14.654"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#7764FF"
+      android:strokeLineCap="square"/>
+  <path
+      android:pathData="M14.667,10.991H7.334"
+      android:strokeLineJoin="round"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#7764FF"
+      android:strokeLineCap="square"/>
+  <path
+      android:pathData="M20.25,13.113V1.75H1.75V20.25H20.25V17.159"
+      android:strokeWidth="2"
+      android:fillColor="#00000000"
+      android:strokeColor="#7764FF"
+      android:strokeLineCap="square"/>
+</vector>

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/PostsRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/PostsRemoteDataSourceImpl.kt
@@ -1,6 +1,7 @@
 package com.mashup.dorabangs.data.datasource.remote.impl
 
 import com.mashup.dorabangs.data.datasource.remote.api.PostsRemoteDataSource
+import com.mashup.dorabangs.data.model.ChangePostFolderIdRequestModel
 import com.mashup.dorabangs.data.model.toData
 import com.mashup.dorabangs.data.model.toDomain
 import com.mashup.dorabangs.data.model.toPagingDomain
@@ -38,5 +39,5 @@ class PostsRemoteDataSourceImpl @Inject constructor(
         postsService.deletePost(postId)
 
     override suspend fun changePostFolder(postId: String, folderId: String) =
-        postsService.changePostFolder(postId, folderId)
+        postsService.changePostFolder(postId, ChangePostFolderIdRequestModel(folderId = folderId))
 }

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/model/ChangePostFolderIdRequestModel.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/model/ChangePostFolderIdRequestModel.kt
@@ -1,0 +1,8 @@
+package com.mashup.dorabangs.data.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ChangePostFolderIdRequestModel(
+    val folderId: String,
+)

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/network/service/PostsService.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/network/service/PostsService.kt
@@ -1,5 +1,6 @@
 package com.mashup.dorabangs.data.network.service
 
+import com.mashup.dorabangs.data.model.ChangePostFolderIdRequestModel
 import com.mashup.dorabangs.data.model.LinkRequestModel
 import com.mashup.dorabangs.data.model.PostInfoRequestModel
 import com.mashup.dorabangs.data.model.PostsResponseModel
@@ -37,6 +38,6 @@ interface PostsService {
     @PATCH("posts/{postId}/move")
     suspend fun changePostFolder(
         @Path("postId") postId: String,
-        @Body folderId: String,
+        @Body folderId: ChangePostFolderIdRequestModel,
     )
 }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
@@ -13,19 +13,23 @@ data class HomeState(
     val feedCards: List<FeedCardUiModel> = emptyList(),
     val folderList: List<Folder> = listOf(),
     val selectedIndex: Int = 0,
-    val isShowMoreButtonSheet: Boolean = true,
+    val selectedPostId: String = "",
+    val selectedFolderId: String = "",
+    val changeFolderId: String = "",
+    val isShowMoreButtonSheet: Boolean = false,
     val isShowDialog: Boolean = false,
     val isShowMovingFolderSheet: Boolean = false,
     val homeCreateFolder: HomeCreateFolder = HomeCreateFolder(),
     val aiClassificationCount: Int = 0,
 ) {
     companion object {
-        fun List<Folder>.toSelectBottomSheetModel(): List<SelectableBottomSheetItemUIModel> {
+        // TODO - 추후 sotrageMapper와 합치기
+        fun List<Folder>.toSelectBottomSheetModel(folderId: String): List<SelectableBottomSheetItemUIModel> {
             return this.map { item ->
                 SelectableBottomSheetItemUIModel(
                     icon = coreR.drawable.ic_3d_folder_big,
                     itemName = item.name,
-                    isSelected = false, // TODO - folderId 같은지 체크
+                    isSelected = item.id == folderId,
                 )
             }
         }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
@@ -1,20 +1,36 @@
 package com.mashup.dorabangs.feature.home
 
+import com.mashup.dorabangs.core.designsystem.component.bottomsheet.SelectableBottomSheetItemUIModel
 import com.mashup.dorabangs.core.designsystem.component.card.FeedCardUiModel
 import com.mashup.dorabangs.core.designsystem.component.chips.DoraChipUiModel
+import com.mashup.dorabangs.domain.model.Folder
 import com.mashup.dorabangs.domain.utils.isValidUrl
+import com.mashup.dorabangs.core.designsystem.R as coreR
 
 data class HomeState(
     val clipBoardState: ClipBoardState = ClipBoardState(),
     val tapElements: List<DoraChipUiModel> = emptyList(),
     val feedCards: List<FeedCardUiModel> = emptyList(),
+    val folderList: List<Folder> = listOf(),
     val selectedIndex: Int = 0,
-    val isShowMoreButtonSheet: Boolean = false,
+    val isShowMoreButtonSheet: Boolean = true,
     val isShowDialog: Boolean = false,
     val isShowMovingFolderSheet: Boolean = false,
     val homeCreateFolder: HomeCreateFolder = HomeCreateFolder(),
     val aiClassificationCount: Int = 0,
-)
+) {
+    companion object {
+        fun List<Folder>.toSelectBottomSheetModel(): List<SelectableBottomSheetItemUIModel> {
+            return this.map { item ->
+                SelectableBottomSheetItemUIModel(
+                    icon = coreR.drawable.ic_3d_folder_big,
+                    itemName = item.name,
+                    isSelected = false, // TODO - folderId 같은지 체크
+                )
+            }
+        }
+    }
+}
 
 data class ClipBoardState(
     val copiedText: String = "",

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
@@ -116,7 +116,7 @@ fun HomeRoute(
         )
 
         DoraBottomSheet.MovingFolderBottomSheet(
-            modifier = Modifier,
+            modifier = modifier,
             isShowSheet = state.isShowMovingFolderSheet,
             folderList = state.folderList.toSelectBottomSheetModel(state.changeFolderId.ifEmpty { state.selectedFolderId }),
             onDismissRequest = { viewModel.setVisibleMovingFolderBottomSheet(false) },

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
@@ -10,6 +10,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ClipboardManager
@@ -21,6 +22,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.mashup.dorabangs.core.designsystem.R
 import com.mashup.dorabangs.core.designsystem.component.bottomsheet.DoraBottomSheet
 import com.mashup.dorabangs.core.designsystem.component.dialog.DoraDialog
+import com.mashup.dorabangs.feature.home.HomeState.Companion.toSelectBottomSheetModel
 import kotlinx.coroutines.launch
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
@@ -105,7 +107,7 @@ fun HomeRoute(
             },
             onClickMoveFolderButton = {
                 viewModel.setVisibleMoreButtonBottomSheet(false)
-                viewModel.setVisibleMovingFolderBottomSheet(true)
+                viewModel.getCustomFolderList()
             },
             onDismissRequest = { viewModel.setVisibleMoreButtonBottomSheet(false) },
         )
@@ -113,7 +115,7 @@ fun HomeRoute(
         DoraBottomSheet.MovingFolderBottomSheet(
             modifier = Modifier.height(441.dp),
             isShowSheet = state.isShowMovingFolderSheet,
-            folderList = testFolderListData,
+            folderList = state.folderList.toSelectBottomSheetModel(),
             onDismissRequest = { viewModel.setVisibleMovingFolderBottomSheet(false) },
             onClickCreateFolder = {
                 viewModel.setVisibleMovingFolderBottomSheet(

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
@@ -69,7 +69,8 @@ fun HomeRoute(
             modifier = modifier,
             onClickChip = viewModel::changeSelectedTapIdx,
             navigateToClassification = navigateToClassification,
-            onClickMoreButton = {
+            onClickMoreButton = { postId, folderId ->
+                viewModel.updateSelectedPostItem(postId = postId, folderId)
                 viewModel.setVisibleMoreButtonBottomSheet(true)
             },
             navigateSaveScreenWithoutLink = navigateToSaveScreenWithoutLink,
@@ -117,7 +118,7 @@ fun HomeRoute(
         DoraBottomSheet.MovingFolderBottomSheet(
             modifier = Modifier.height(441.dp),
             isShowSheet = state.isShowMovingFolderSheet,
-            folderList = state.folderList.toSelectBottomSheetModel(),
+            folderList = state.folderList.toSelectBottomSheetModel(state.changeFolderId.ifEmpty { state.selectedFolderId }),
             onDismissRequest = { viewModel.setVisibleMovingFolderBottomSheet(false) },
             onClickCreateFolder = {
                 viewModel.setVisibleMovingFolderBottomSheet(
@@ -125,7 +126,9 @@ fun HomeRoute(
                     isNavigate = true,
                 )
             },
-            onClickMoveFolder = {},
+            onClickMoveFolder = { selectFolder -> viewModel.updateSelectFolderId(selectFolder) },
+            btnEnable = state.selectedFolderId != state.changeFolderId,
+            onClickCompleteButton = { viewModel.moveFolder(state.selectedPostId, state.changeFolderId) },
         )
 
         DoraDialog(
@@ -135,7 +138,7 @@ fun HomeRoute(
             confirmBtnText = stringResource(R.string.remove_dialog_confirm),
             disMissBtnText = stringResource(R.string.remove_dialog_cancil),
             onDisMissRequest = { viewModel.setVisibleDialog(false) },
-            onClickConfirmBtn = { viewModel.setVisibleDialog(false) },
+            onClickConfirmBtn = { viewModel.deletePost(state.selectedPostId) },
         )
     }
 }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
@@ -116,7 +116,7 @@ fun HomeRoute(
         )
 
         DoraBottomSheet.MovingFolderBottomSheet(
-            modifier = Modifier.height(441.dp),
+            modifier = Modifier,
             isShowSheet = state.isShowMovingFolderSheet,
             folderList = state.folderList.toSelectBottomSheetModel(state.changeFolderId.ifEmpty { state.selectedFolderId }),
             onDismissRequest = { viewModel.setVisibleMovingFolderBottomSheet(false) },

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeScreen.kt
@@ -43,7 +43,6 @@ import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.mashup.dorabangs.core.designsystem.R
-import com.mashup.dorabangs.core.designsystem.component.bottomsheet.SelectableBottomSheetItemUIModel
 import com.mashup.dorabangs.core.designsystem.component.buttons.GradientButton
 import com.mashup.dorabangs.core.designsystem.component.card.FeedCard
 import com.mashup.dorabangs.core.designsystem.component.card.FeedCardUiModel
@@ -66,7 +65,7 @@ fun HomeScreen(
     state: HomeState,
     modifier: Modifier = Modifier,
     onClickChip: (Int) -> Unit = {},
-    onClickMoreButton: (Int) -> Unit = {},
+    onClickMoreButton: (String, String) -> Unit,
     navigateToClassification: () -> Unit = {},
     navigateSaveScreenWithoutLink: () -> Unit = {},
     navigateToHomeTutorial: () -> Unit = {},
@@ -159,8 +158,8 @@ fun HomeScreen(
                 Feeds(
                     modifier = Modifier,
                     feeds = state.feedCards,
-                    onClickMoreButton = { index ->
-                        onClickMoreButton(index)
+                    onClickMoreButton = { postId, folderId ->
+                        onClickMoreButton(postId, folderId)
                     },
                 )
             }
@@ -201,13 +200,13 @@ fun HomeScreen(
 private fun LazyListScope.Feeds(
     feeds: List<FeedCardUiModel>,
     modifier: Modifier = Modifier,
-    onClickMoreButton: (Int) -> Unit = {},
+    onClickMoreButton: (String, String) -> Unit,
 ) {
     items(feeds.size) { index ->
         FeedCard(
             cardInfo = feeds[index],
             onClickMoreButton = {
-                onClickMoreButton(index)
+                onClickMoreButton(feeds[index].id, feeds[index].folderId)
             },
         )
         if (index != feeds.lastIndex) {
@@ -388,6 +387,7 @@ fun HomeCarouselPreview() {
 @Composable
 fun HomeScreenPreview() {
     HomeScreen(
+        onClickMoreButton = { postId, folderId -> },
         state = HomeState(
             tapElements = listOf(
                 DoraChipUiModel(
@@ -415,26 +415,3 @@ fun HomeScreenPreview() {
         ),
     )
 }
-
-val testFolderListData = listOf(
-    SelectableBottomSheetItemUIModel(
-        R.drawable.ic_plus,
-        "폴더이름",
-        false,
-    ),
-    SelectableBottomSheetItemUIModel(
-        R.drawable.ic_plus,
-        "폴더이름",
-        false,
-    ),
-    SelectableBottomSheetItemUIModel(
-        R.drawable.ic_plus,
-        "폴더이름",
-        true,
-    ),
-    SelectableBottomSheetItemUIModel(
-        R.drawable.ic_plus,
-        "폴더이름",
-        false,
-    ),
-)

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
@@ -218,6 +218,19 @@ class HomeViewModel @Inject constructor(
         }
     }
 
+    /**
+     * 현재 폴더 리스트 가져오기
+     */
+    fun getCustomFolderList() = viewModelScope.doraLaunch {
+        val customFolderList = getFolderList().customFolders
+        intent {
+            reduce {
+                state.copy(folderList = customFolderList)
+            }
+            setVisibleMovingFolderBottomSheet(true)
+        }
+    }
+
     init {
         intent {
             reduce {

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
@@ -259,7 +259,6 @@ class HomeViewModel @Inject constructor(
     fun deletePost(postId: String) = viewModelScope.doraLaunch {
         deletePostUseCase(postId)
         setVisibleDialog(false)
-        intent { }
     }
 
     /**

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
@@ -1,7 +1,5 @@
 package com.mashup.dorabangs.feature.home
 
-import android.content.ContentValues.TAG
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -57,7 +55,7 @@ class HomeViewModel @Inject constructor(
                 savedStateHandle.getStateFlow(
                     "isVisibleMovingBottomSheet",
                     initialValue = false,
-                ).collect { isVisible -> setVisibleMovingFolderBottomSheet(visible = isVisible) }
+                ).collect { isVisible -> if (isVisible) getCustomFolderList() }
             }
             launch {
                 savedStateHandle.getStateFlow(

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/navigation/HomeCreateFolderNavigation.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/navigation/HomeCreateFolderNavigation.kt
@@ -15,7 +15,7 @@ import java.nio.charset.StandardCharsets
 
 fun NavController.navigateToHomeCrateFolder(navOptions: NavOptions? = null, urlLink: String = "") {
     val encodedUrl = URLEncoder.encode(urlLink, StandardCharsets.UTF_8.toString())
-    navigate("${NavigationRoute.HomeScreen.HomeCreateFolderWithLink.route}/$encodedUrl", navOptions)
+    navigate("${NavigationRoute.HomeScreen.HomeCreateFolderWithLink.route}/$encodedUrl?", navOptions)
 }
 
 fun NavGraphBuilder.homeCreateFolderNavigation(
@@ -25,7 +25,7 @@ fun NavGraphBuilder.homeCreateFolderNavigation(
     navigateToHomeAfterSaveLink: () -> Unit,
 ) {
     composable(
-        route = "${NavigationRoute.HomeScreen.HomeCreateFolderWithLink.route}/{urlLink}",
+        route = "${NavigationRoute.HomeScreen.HomeCreateFolderWithLink.route}/{urlLink}?",
         arguments = listOf(
             navArgument("urlLink") {
                 type = NavType.StringType
@@ -37,7 +37,7 @@ fun NavGraphBuilder.homeCreateFolderNavigation(
             val homeViewModel: HomeViewModel = hiltViewModel(backStackEntry)
             val urlLink = it.arguments?.getString("urlLink").orEmpty()
             homeViewModel.savedStateHandle["urlLink"] = urlLink
-            homeViewModel.savedStateHandle["isVisibleMovingBottomSheet"] = urlLink.isBlank()
+            homeViewModel.savedStateHandle["isVisibleMovingBottomSheet"] = urlLink.isEmpty()
 
             HomeCreateFolderRoute(
                 homeViewModel = homeViewModel,

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
@@ -128,11 +128,13 @@ fun StorageDetailRoute(
     DoraBottomSheet.MovingFolderBottomSheet(
         modifier = modifier,
         isShowSheet = state.isShowMovingFolderSheet,
-        folderList = state.folderList.toSelectBottomSheetModel(state.changeClickFolderId.ifEmpty {
-            val originFolder = state.folderInfo.folderId.orEmpty()
-            storageDetailViewModel.updateSelectFolderId(originFolder)
-            originFolder
-        }),
+        folderList = state.folderList.toSelectBottomSheetModel(
+            state.changeClickFolderId.ifEmpty {
+                val originFolder = state.folderInfo.folderId.orEmpty()
+                storageDetailViewModel.updateSelectFolderId(originFolder)
+                originFolder
+            },
+        ),
         onDismissRequest = { storageDetailViewModel.setVisibleMovingFolderBottomSheet(false) },
         onClickCreateFolder = {
             storageDetailViewModel.setVisibleMovingFolderBottomSheet(

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
@@ -128,7 +128,11 @@ fun StorageDetailRoute(
     DoraBottomSheet.MovingFolderBottomSheet(
         modifier = modifier,
         isShowSheet = state.isShowMovingFolderSheet,
-        folderList = state.folderList.toSelectBottomSheetModel(state.changeClickFolderId.ifEmpty { state.folderInfo.folderId.orEmpty() }),
+        folderList = state.folderList.toSelectBottomSheetModel(state.changeClickFolderId.ifEmpty {
+            val originFolder = state.folderInfo.folderId.orEmpty()
+            storageDetailViewModel.updateSelectFolderId(originFolder)
+            originFolder
+        }),
         onDismissRequest = { storageDetailViewModel.setVisibleMovingFolderBottomSheet(false) },
         onClickCreateFolder = {
             storageDetailViewModel.setVisibleMovingFolderBottomSheet(

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
@@ -41,6 +41,7 @@ fun StorageDetailRoute(
     navigateToFolderManager: (String) -> Unit,
     navigateToCreateFolder: () -> Unit,
     onClickBackIcon: () -> Unit,
+    modifier: Modifier = Modifier,
     isVisibleBottomSheet: Boolean = false,
     storageDetailViewModel: StorageDetailViewModel = hiltViewModel(),
 ) {
@@ -125,7 +126,7 @@ fun StorageDetailRoute(
     )
 
     DoraBottomSheet.MovingFolderBottomSheet(
-        modifier = Modifier.height(441.dp),
+        modifier = modifier,
         isShowSheet = state.isShowMovingFolderSheet,
         folderList = state.folderList.toSelectBottomSheetModel(state.changeClickFolderId.ifEmpty { state.folderInfo.folderId.orEmpty() }),
         onDismissRequest = { storageDetailViewModel.setVisibleMovingFolderBottomSheet(false) },

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
@@ -27,7 +27,7 @@ import com.mashup.dorabangs.feature.storage.storagedetail.model.EditActionType
 import com.mashup.dorabangs.feature.storage.storagedetail.model.StorageDetailSideEffect
 import com.mashup.dorabangs.feature.storage.storagedetail.model.StorageDetailSort
 import com.mashup.dorabangs.feature.storage.storagedetail.model.StorageDetailState
-import com.mashup.dorabangs.feature.storage.storagedetail.model.toBottomSheetModel
+import com.mashup.dorabangs.feature.storage.storagedetail.model.toSelectBottomSheetModel
 import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 
@@ -103,7 +103,7 @@ fun StorageDetailRoute(
             storageDetailViewModel.setVisibleMoreButtonBottomSheet(false)
             when (state.editActionType) {
                 EditActionType.FolderEdit -> storageDetailViewModel.moveToEditFolderName(state.folderInfo.folderId)
-                EditActionType.LinkEdit -> storageDetailViewModel.getFolderList()
+                EditActionType.LinkEdit -> storageDetailViewModel.getCustomFolderList()
             }
         },
         onDismissRequest = { storageDetailViewModel.setVisibleMoreButtonBottomSheet(false) },
@@ -127,7 +127,7 @@ fun StorageDetailRoute(
     DoraBottomSheet.MovingFolderBottomSheet(
         modifier = Modifier.height(441.dp),
         isShowSheet = state.isShowMovingFolderSheet,
-        folderList = state.folderList.map { it.toBottomSheetModel(state.folderInfo.folderId.orEmpty()) },
+        folderList = state.folderList.toSelectBottomSheetModel(state.changeClickFolderId.ifEmpty { state.folderInfo.folderId.orEmpty() }),
         onDismissRequest = { storageDetailViewModel.setVisibleMovingFolderBottomSheet(false) },
         onClickCreateFolder = {
             storageDetailViewModel.setVisibleMovingFolderBottomSheet(
@@ -135,7 +135,14 @@ fun StorageDetailRoute(
                 isNavigate = true,
             )
         },
-        onClickMoveFolder = {},
+        onClickMoveFolder = { selectFolderId -> storageDetailViewModel.updateSelectFolderId(selectFolderId) },
+        btnEnable = state.folderInfo.folderId != state.changeClickFolderId,
+        onClickCompleteButton = {
+            storageDetailViewModel.moveFolder(
+                postId = state.currentClickPostId,
+                folderId = state.changeClickFolderId,
+            )
+        },
     )
 }
 

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailViewModel.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailViewModel.kt
@@ -1,7 +1,5 @@
 package com.mashup.dorabangs.feature.storage.storagedetail
 
-import android.content.ContentValues.TAG
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailViewModel.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailViewModel.kt
@@ -286,7 +286,6 @@ class StorageDetailViewModel @Inject constructor(
     }
 
     fun updateSelectFolderId(folderId: String) = intent {
-        Log.d(TAG, "updateSelectFolderId: $folderId")
         reduce { state.copy(changeClickFolderId = folderId) }
     }
 

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/PostCardMapper.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/PostCardMapper.kt
@@ -16,6 +16,7 @@ fun SavedLinkDetailInfo.toUiModel(): FeedCardUiModel {
         keywordList = this.keywords?.map { it.name },
         isFavorite = isFavorite ?: false,
         thumbnail = "",
+        folderId = this.folderId.orEmpty(),
     )
 }
 
@@ -28,13 +29,17 @@ fun Post.toUiModel(): FeedCardUiModel {
         keywordList = listOf(),
         isFavorite = isFavorite,
         thumbnail = "",
+        folderId = this.folderId,
     )
 }
 
-fun Folder.toBottomSheetModel(currentFolderId: String): SelectableBottomSheetItemUIModel {
-    return SelectableBottomSheetItemUIModel(
-        icon = coreR.drawable.ic_3d_folder_small,
-        itemName = name,
-        isSelected = id == currentFolderId,
-    )
+fun List<Folder>.toSelectBottomSheetModel(folderId: String): List<SelectableBottomSheetItemUIModel> {
+    return this.map { item ->
+        SelectableBottomSheetItemUIModel(
+            id = item.id.orEmpty(),
+            icon = coreR.drawable.ic_3d_folder_big,
+            itemName = item.name,
+            isSelected = item.id == folderId,
+        )
+    }
 }

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/StorageDetailState.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/StorageDetailState.kt
@@ -18,6 +18,7 @@ data class StorageDetailState(
     val isLatestSort: StorageDetailSort = StorageDetailSort.ASC,
     val editActionType: EditActionType = EditActionType.FolderEdit,
     val currentClickPostId: String = "",
+    val changeClickFolderId: String = folderInfo.folderId.orEmpty(),
     val folderList: List<Folder> = listOf(),
     val pagingList: Flow<PagingData<FeedCardUiModel>> = emptyFlow(),
 

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/StorageDetailState.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/StorageDetailState.kt
@@ -28,6 +28,7 @@ fun SavedLinkDetailInfo.toUiModel(): FeedCardUiModel {
     return FeedCardUiModel(
         id = this.id.orEmpty(),
         title = this.title,
+        folderId = this.folderId.orEmpty(),
         content = this.description,
         createdAt = this.createdAt,
         keywordList = this.keywords?.map { it.name },
@@ -45,5 +46,6 @@ fun Post.toUiModel(): FeedCardUiModel {
         keywordList = listOf(),
         isFavorite = isFavorite,
         thumbnail = "",
+        folderId = this.folderId
     )
 }


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약
- 바텀시트 수정 및 API 연결

## 작업 내용
> 실제 작업 내용

- 바텀 시트 폴더이동 눌렀을 때 높이 확장되도록 수정
- 현재 선택된 폴더인경우에 따라 버튼 Enable 처리 추가
- 변경할 폴더 선택 시 폴더 이동 API 호출

## 시연 화면 (option)
> 실행 스크린샷 혹은 영상 첨부

https://github.com/user-attachments/assets/7deec8da-8786-4cae-82f1-4e636b378078


## To Reviers
> 리뷰어들에게 전할 말

- 네비게이션 바때문에 `DoraBottomSheet`에서 windowInset를 설정해줬는데.. 이상하게 이거 설정하면 약간 부자연스러워요ㅠㅠㅠ
  안하면 네비게이션이랑 바텀시트랑 겹쳐보이는 이슈가 있슴당ㅠ
- 폴더 이동에서 새폴더 추가 후에 저장 버튼 누르면 폴더추가 API 호출후에 이동 API까지 호출해야하는데 이건 다음 보관함버그픽스 pr에서 올릴게유
- 홈에서 폴더이동 > 새폴더 추가 진입 후에 백버튼 누르면 다시 바텀시트떠야하자나용! 그때 폴더리스트 데이터들을 다시불러와주는데 API 응답 늦는 경우 바텀시트 늦게뜨는 이슈가,, 좋은 방법 있으면 알려주세용

컴포즈 바텀시트 개같다!!!!!!!!!!!!!!!!!!!

## Close
close #97 