### PR TITLE
홈화면에서 드디어 폴더 이동을 할 수 있게되었다는...소문이...

### DIFF
--- a/app/src/main/java/com/mashup/dorabangs/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/mashup/dorabangs/navigation/MainNavHost.kt
@@ -68,6 +68,9 @@ fun MainNavHost(
                     isVisibleMovingBottomSheet = false,
                 )
             },
+            navigateToHomeAfterMovingFolder = {
+                appState.navController.popBackStack()
+            },
         )
         homeTutorialNavigation(
             navigateToHome = { appState.navController.popBackStack() },

--- a/app/src/main/java/com/mashup/dorabangs/navigation/MainNavHost.kt
+++ b/app/src/main/java/com/mashup/dorabangs/navigation/MainNavHost.kt
@@ -60,6 +60,11 @@ fun MainNavHost(
             onClickBackIcon = {
                 appState.navController.navigateToHome(
                     isVisibleMovingBottomSheet = true,
+                    navOptions = navOptions {
+                        popUpTo(appState.navController.graph.id) {
+                            inclusive = true
+                        }
+                    },
                 )
             },
             navigateToHome = { appState.navController.popBackStack() },

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
@@ -1,5 +1,7 @@
 package com.mashup.dorabangs.core.designsystem.component.bottomsheet
 
+import android.content.ContentValues.TAG
+import android.util.Log
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -116,7 +118,10 @@ object DoraBottomSheet : BottomSheetType {
                         DoraBottomSheetFolderItem(
                             modifier = Modifier.fillMaxWidth(),
                             data = folderList[index],
-                            onClickItem = { onClickMoveFolder(folderList[index].id) },
+                            onClickItem = {
+                                Log.d(TAG, "MovingFolderBottomSheet: ${folderList[index].id}")
+                                onClickMoveFolder(folderList[index].id)
+                            },
                             isLastItem = index == folderList.lastIndex,
                         )
                     }

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/bottomsheet/BottomSheetType.kt
@@ -1,7 +1,5 @@
 package com.mashup.dorabangs.core.designsystem.component.bottomsheet
 
-import android.content.ContentValues.TAG
-import android.util.Log
 import androidx.annotation.StringRes
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -119,7 +117,6 @@ object DoraBottomSheet : BottomSheetType {
                             modifier = Modifier.fillMaxWidth(),
                             data = folderList[index],
                             onClickItem = {
-                                Log.d(TAG, "MovingFolderBottomSheet: ${folderList[index].id}")
                                 onClickMoveFolder(folderList[index].id)
                             },
                             isLastItem = index == folderList.lastIndex,

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -86,7 +87,7 @@ fun FeedCard(
             Spacer(modifier = Modifier.width(13.dp))
             AsyncImage(
                 modifier = Modifier
-                    .size(size = 65.dp)
+                    .size(size = 80.dp).aspectRatio(1f)
                     .background(color = DoraColorTokens.G1),
                 model = cardInfo.thumbnail,
                 contentScale = ContentScale.Crop,

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
@@ -87,7 +87,8 @@ fun FeedCard(
             Spacer(modifier = Modifier.width(13.dp))
             AsyncImage(
                 modifier = Modifier
-                    .size(size = 80.dp).aspectRatio(1f)
+                    .size(size = 80.dp)
+                    .aspectRatio(1f)
                     .background(color = DoraColorTokens.G1),
                 model = cardInfo.thumbnail,
                 contentScale = ContentScale.Crop,

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/createfolder/HomeCreateFolderScreen.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/createfolder/HomeCreateFolderScreen.kt
@@ -42,7 +42,10 @@ fun HomeCreateFolderRoute(
                 urlLink = sideEffect.urlLink,
             )
             is HomeSideEffect.NavigateHomeAfterSaveLink -> navigateToHomeAfterSaveLink()
-            is HomeSideEffect.NavigateToCompleteMovingFolder -> navigateToHomeAfterMovingFolder()
+            is HomeSideEffect.NavigateToCompleteMovingFolder -> {
+                homeViewModel.setVisibleMovingFolderBottomSheet(false)
+                navigateToHomeAfterMovingFolder()
+            }
             else -> {}
         }
     }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/createfolder/HomeCreateFolderScreen.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/createfolder/HomeCreateFolderScreen.kt
@@ -30,6 +30,7 @@ fun HomeCreateFolderRoute(
     onClickBackIcon: () -> Unit,
     navigateToHome: () -> Unit,
     navigateToHomeAfterSaveLink: () -> Unit,
+    navigateToHomeAfterMovingFolder: () -> Unit,
 ) {
     val state by homeViewModel.collectAsState()
 
@@ -41,14 +42,23 @@ fun HomeCreateFolderRoute(
                 urlLink = sideEffect.urlLink,
             )
             is HomeSideEffect.NavigateHomeAfterSaveLink -> navigateToHomeAfterSaveLink()
+            is HomeSideEffect.NavigateToCompleteMovingFolder -> navigateToHomeAfterMovingFolder()
             else -> {}
         }
     }
 
     HomeCreateFolderScreen(
         state = state.homeCreateFolder,
-        onClickBackIcon = onClickBackIcon,
-        onClickSaveButton = { homeViewModel.createFolder(state.homeCreateFolder.folderName, state.homeCreateFolder.urlLink) },
+        onClickBackIcon = {
+            homeViewModel.updateEditType(isEditPostFolder = false)
+            onClickBackIcon()
+        },
+        onClickSaveButton = {
+            if (state.isEditPostFolder) {
+                homeViewModel.createFolderWithMoveLink(state.homeCreateFolder.folderName, state.selectedPostId)
+            } else {
+                homeViewModel.createFolder(state.homeCreateFolder.folderName, state.homeCreateFolder.urlLink) }
+        },
         onValueChanged = homeViewModel::setFolderName,
     )
 }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
@@ -27,6 +27,7 @@ data class HomeState(
     val aiClassificationCount: Int = 0,
     val toastState: ToastState = ToastState(),
     val unReadPostCount: Int = 0,
+    val isEditPostFolder: Boolean = false,
 ) {
     companion object {
         // TODO - 추후 sotrageMapper와 합치기

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
@@ -19,7 +19,7 @@ data class HomeState(
     val selectedIndex: Int = 0,
     val selectedPostId: String = "",
     val selectedFolderId: String = "",
-    val changeFolderId: String = "",
+    val changeFolderId: String = selectedFolderId,
     val isShowMoreButtonSheet: Boolean = false,
     val isShowDialog: Boolean = false,
     val isShowMovingFolderSheet: Boolean = false,
@@ -33,6 +33,7 @@ data class HomeState(
         fun List<Folder>.toSelectBottomSheetModel(folderId: String): List<SelectableBottomSheetItemUIModel> {
             return this.map { item ->
                 SelectableBottomSheetItemUIModel(
+                    id = item.id.orEmpty(),
                     icon = coreR.drawable.ic_3d_folder_big,
                     itemName = item.name,
                     isSelected = item.id == folderId,

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
@@ -123,15 +123,26 @@ fun HomeRoute(
         DoraBottomSheet.MovingFolderBottomSheet(
             modifier = modifier,
             isShowSheet = state.isShowMovingFolderSheet,
-            folderList = state.folderList.toSelectBottomSheetModel(state.changeFolderId.ifEmpty { state.selectedFolderId }),
-            onDismissRequest = { viewModel.setVisibleMovingFolderBottomSheet(false) },
+            folderList = state.folderList.toSelectBottomSheetModel(
+                state.changeFolderId.ifEmpty {
+                    val originFolder = state.selectedFolderId
+                    viewModel.updateSelectFolderId(originFolder)
+                    originFolder
+                },
+            ),
+            onDismissRequest = {
+                viewModel.updateSelectFolderId(state.selectedFolderId)
+                viewModel.setVisibleMovingFolderBottomSheet(false)
+            },
             onClickCreateFolder = {
                 viewModel.setVisibleMovingFolderBottomSheet(
                     visible = false,
                     isNavigate = true,
                 )
             },
-            onClickMoveFolder = { selectFolder -> viewModel.updateSelectFolderId(selectFolder) },
+            onClickMoveFolder = { selectFolder ->
+                viewModel.updateSelectFolderId(selectFolder)
+            },
             btnEnable = state.selectedFolderId != state.changeFolderId,
             onClickCompleteButton = { viewModel.moveFolder(state.selectedPostId, state.changeFolderId) },
         )

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeRoute.kt
@@ -59,7 +59,10 @@ fun HomeRoute(
                 snackBarHostState.currentSnackbarData?.dismiss()
             }
 
-            is HomeSideEffect.NavigateToCreateFolder -> navigateToCreateFolder()
+            is HomeSideEffect.NavigateToCreateFolder -> {
+                viewModel.updateEditType(isEditPostFolder = true)
+                navigateToCreateFolder()
+            }
 
             is HomeSideEffect.RefreshPostList -> pagingList.refresh()
             else -> {}

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeSideEffect.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeSideEffect.kt
@@ -9,4 +9,5 @@ sealed class HomeSideEffect {
     object NavigateHomeAfterSaveLink : HomeSideEffect()
     data class NavigateSelectLinkFromService(val urlLink: String) : HomeSideEffect()
     object RefreshPostList : HomeSideEffect()
+    object NavigateToCompleteMovingFolder : HomeSideEffect()
 }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
@@ -366,7 +366,7 @@ class HomeViewModel @Inject constructor(
         val isSuccess = changePostFolderUseCase(postId = postId, folderId = folderId).isSuccess
         setVisibleMovingFolderBottomSheet(false)
         if (isSuccess) {
-            // intent { postSideEffect(StorageDetailSideEffect.RefreshPagingList) }
+            // intent { postSideEffect(HomeSideEffect) }
         }
     }
 

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
@@ -372,6 +372,30 @@ class HomeViewModel @Inject constructor(
             // intent { postSideEffect(StorageDetailSideEffect.RefreshPagingList) }
         }
     }
+
+    /**
+     * 링크 수정 - 새 폴더 추가 후 폴더 이동
+     */
+    fun createFolderWithMoveLink(folderName: String, postId: String) = viewModelScope.doraLaunch {
+        val newFolder = createFolderUseCase.invoke(folderList = NewFolderNameList(names = listOf(folderName)))
+        if (newFolder.isSuccess) {
+            val newFolderId = newFolder.result.firstOrNull()?.id
+            newFolderId?.let { folderId ->
+                val moveFolder = changePostFolderUseCase.invoke(postId = postId, folderId = folderId)
+                if (moveFolder.isSuccess) {
+                    intent {
+                        postSideEffect(HomeSideEffect.NavigateToCompleteMovingFolder)
+                        updateEditType(isEditPostFolder = false)
+                    }
+                }
+            }
+        }
+    }
+
+    fun updateEditType(isEditPostFolder: Boolean) = intent {
+        reduce { state.copy(isEditPostFolder = isEditPostFolder) }
+    }
+
     companion object {
         const val FAVORITE_FOLDER_INDEX = 1
     }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
@@ -1,5 +1,7 @@
 package com.mashup.dorabangs.feature.home
 
+import android.content.ContentValues.TAG
+import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -356,6 +358,7 @@ class HomeViewModel @Inject constructor(
     }
 
     fun updateSelectFolderId(folderId: String) = intent {
+        Log.d(TAG, "updateSelectFolderId: $folderId")
         reduce { state.copy(changeFolderId = folderId) }
     }
 
@@ -363,11 +366,12 @@ class HomeViewModel @Inject constructor(
      * 링크 폴더 이동
      */
     fun moveFolder(postId: String, folderId: String) = viewModelScope.doraLaunch {
-        changePostFolderUseCase(postId = postId, folderId = folderId)
+        val isSuccess = changePostFolderUseCase(postId = postId, folderId = folderId).isSuccess
         setVisibleMovingFolderBottomSheet(false)
-        // TODO - 실패 성공 여부 리스트 업데이트
+        if (isSuccess) {
+            // intent { postSideEffect(StorageDetailSideEffect.RefreshPagingList) }
+        }
     }
-
     companion object {
         const val FAVORITE_FOLDER_INDEX = 1
     }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
@@ -1,7 +1,5 @@
 package com.mashup.dorabangs.feature.home
 
-import android.content.ContentValues.TAG
-import android.util.Log
 import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
@@ -358,7 +356,6 @@ class HomeViewModel @Inject constructor(
     }
 
     fun updateSelectFolderId(folderId: String) = intent {
-        Log.d(TAG, "updateSelectFolderId: $folderId")
         reduce { state.copy(changeFolderId = folderId) }
     }
 

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/navigation/HomeCreateFolderNavigation.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/navigation/HomeCreateFolderNavigation.kt
@@ -15,7 +15,7 @@ import java.nio.charset.StandardCharsets
 
 fun NavController.navigateToHomeCrateFolder(navOptions: NavOptions? = null, urlLink: String = "") {
     val encodedUrl = URLEncoder.encode(urlLink, StandardCharsets.UTF_8.toString())
-    navigate("${NavigationRoute.HomeScreen.HomeCreateFolderWithLink.route}/$encodedUrl?", navOptions)
+    navigate("${NavigationRoute.HomeScreen.HomeCreateFolderWithLink.route}/?$encodedUrl", navOptions)
 }
 
 fun NavGraphBuilder.homeCreateFolderNavigation(
@@ -23,9 +23,10 @@ fun NavGraphBuilder.homeCreateFolderNavigation(
     onClickBackIcon: () -> Unit,
     navigateToHome: () -> Unit,
     navigateToHomeAfterSaveLink: () -> Unit,
+    navigateToHomeAfterMovingFolder: () -> Unit,
 ) {
     composable(
-        route = "${NavigationRoute.HomeScreen.HomeCreateFolderWithLink.route}/{urlLink}?",
+        route = "${NavigationRoute.HomeScreen.HomeCreateFolderWithLink.route}/?{urlLink}",
         arguments = listOf(
             navArgument("urlLink") {
                 type = NavType.StringType
@@ -44,11 +45,13 @@ fun NavGraphBuilder.homeCreateFolderNavigation(
                 onClickBackIcon = onClickBackIcon,
                 navigateToHome = navigateToHome,
                 navigateToHomeAfterSaveLink = navigateToHomeAfterSaveLink,
+                navigateToHomeAfterMovingFolder = navigateToHomeAfterMovingFolder,
             )
         } ?: HomeCreateFolderRoute(
             onClickBackIcon = onClickBackIcon,
             navigateToHome = navigateToHome,
             navigateToHomeAfterSaveLink = navigateToHomeAfterSaveLink,
+            navigateToHomeAfterMovingFolder = navigateToHomeAfterMovingFolder,
         )
     }
 }

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
@@ -161,7 +161,10 @@ fun StorageDetailRoute(
                     originFolder
                 },
             ),
-            onDismissRequest = { storageDetailViewModel.setVisibleMovingFolderBottomSheet(false) },
+            onDismissRequest = {
+                storageDetailViewModel.updateSelectFolderId(state.folderInfo.folderId.orEmpty())
+                storageDetailViewModel.setVisibleMovingFolderBottomSheet(false)
+            },
             onClickCreateFolder = {
                 storageDetailViewModel.setVisibleMovingFolderBottomSheet(
                     visible = false,


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약

## 작업 내용
> 실제 작업 내용

- 홈화면에서 피드 더보기 > 폴더 이동 바텀시트 > 폴더 이동 API 로직 추가
- 폴더 이동 바텀시트 > 새폴더 추가 후 바로 폴더 이동 할 수 있도록 로직 추가


## 시연 화면 (option)
> 실행 스크린샷 혹은 영상 첨부

https://github.com/user-attachments/assets/c2f3a589-8d69-42c2-b2f0-8514adb213af



## To Reviers
> 리뷰어들에게 전할 말
도라방구리 화이팅!!

-하다보니 EditText있는쪽에서 키보드 먼저 내리고 화면 전환이 필요할 것 같다는 생각이~~~
- 하나는 질문인데용! 피드에서 폴더 이동 바텀시트 > 새폴더 추가 후 바로 폴더 이동 후에 홈돌아왔을 때 
데이터 업데이트가 필요할 것 같은데 어떤 방식으로 하는게 좋을까욥,,, -> 해당 포스트값만 업데이트 쳐주는게 좋겟죵?
(이건 물어보고 작업하겟삼)

## Close
close #