### PR TITLE
피드에서 웹뷰 이동하여 읽음 처리 시 null request 빼기

### DIFF
--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
@@ -113,7 +113,7 @@ fun FeedCard(
             )
         } else {
             Spacer(modifier = Modifier.height(12.dp))
-            FeedCardKeyword(keywordList = cardInfo.keywordList?.take(3))
+            FeedCardKeyword(keywordList = cardInfo.keywordList?.filterNotNull()?.take(3))
             Spacer(modifier = Modifier.height(16.dp))
             Row(
                 modifier = Modifier.fillMaxWidth(),

--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/chips/FeedUiModel.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/chips/FeedUiModel.kt
@@ -18,7 +18,7 @@ sealed interface FeedUiModel {
         val content: String? = "",
         val category: String? = "",
         val createdAt: String? = "",
-        val keywordList: List<String>? = listOf(),
+        val keywordList: List<String?>? = listOf(),
         val thumbnail: String? = "",
         val isFavorite: Boolean = false,
         val isLoading: Boolean = false,

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/di/NetworkModule.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/di/NetworkModule.kt
@@ -12,6 +12,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.json.Json
 import okhttp3.Interceptor
 import okhttp3.MediaType.Companion.toMediaType
@@ -70,6 +71,7 @@ object NetworkModule {
     @Singleton
     fun providesConverterFactory(json: Json): Converter.Factory = json.asConverterFactory("application/json".toMediaType())
 
+    @OptIn(ExperimentalSerializationApi::class)
     @Provides
     @Singleton
     fun providesJsonBuilder(): Json =
@@ -77,6 +79,7 @@ object NetworkModule {
             isLenient = true
             ignoreUnknownKeys = true
             coerceInputValues = true
+            explicitNulls = false
         }
 
     @Provides

--- a/domain/src/main/kotlin/com/mashup/dorabangs/domain/model/SavedLinkListFromFolder.kt
+++ b/domain/src/main/kotlin/com/mashup/dorabangs/domain/model/SavedLinkListFromFolder.kt
@@ -17,5 +17,5 @@ data class SavedLinkDetailInfo(
 
 data class LinkKeywordInfo(
     val id: String,
-    val name: String,
+    val name: String?,
 )

--- a/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
+++ b/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
@@ -228,7 +228,7 @@ class ClassificationViewModel @Inject constructor(
             if (cardInfo.readAt.isNullOrEmpty()) {
                 patchPostInfoUseCase.invoke(
                     postId = cardInfo.postId,
-                    PostInfo(isFavorite = cardInfo.isFavorite, readAt = FeedUiModel.FeedCardUiModel.createCurrentTime()),
+                    PostInfo(readAt = FeedUiModel.FeedCardUiModel.createCurrentTime()),
                 )
             }
         }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeViewModel.kt
@@ -401,7 +401,7 @@ class HomeViewModel @Inject constructor(
             if (cardInfo.readAt.isNullOrEmpty()) {
                 patchPostInfoUseCase.invoke(
                     postId = cardInfo.postId,
-                    PostInfo(isFavorite = cardInfo.isFavorite, readAt = FeedUiModel.FeedCardUiModel.createCurrentTime()),
+                    PostInfo(readAt = FeedUiModel.FeedCardUiModel.createCurrentTime()),
                 )
             }
         }

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailViewModel.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailViewModel.kt
@@ -288,7 +288,7 @@ class StorageDetailViewModel @Inject constructor(
             }
             val isSuccessFavorite = patchPostInfoUseCase(
                 postId = cardInfo.postId,
-                postInfo = PostInfo(isFavorite = !isFavorite, readAt = cardInfo.readAt),
+                postInfo = PostInfo(isFavorite = !isFavorite),
             ).isSuccess
 
             if (isSuccessFavorite) {
@@ -397,7 +397,7 @@ class StorageDetailViewModel @Inject constructor(
             if (cardInfo.readAt.isNullOrEmpty()) {
                 patchPostInfoUseCase.invoke(
                     postId = cardInfo.postId,
-                    PostInfo(isFavorite = cardInfo.isFavorite, readAt = createCurrentTime()),
+                    PostInfo(readAt = createCurrentTime()),
                 )
             }
         }

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailViewModel.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailViewModel.kt
@@ -280,8 +280,8 @@ class StorageDetailViewModel @Inject constructor(
             var updateItemInfo = FeedUiModel.FeedCardUiModel()
             _feedListState.value = feedListState.value.map { item ->
                 if (item.postId == cardInfo.postId) {
-                    updateItemInfo = item.copy(isFavorite = !isFavorite)
-                    item.copy(isFavorite = !isFavorite)
+                    updateItemInfo = item.copy(isFavorite = isFavorite.not())
+                    item.copy(isFavorite = isFavorite.not())
                 } else {
                     item
                 }


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약
피드에서 웹뷰 이동하여 읽음 처리 시 null request 빼기

## 작업 내용
> 실제 작업 내용

- 이전 pr를 닫아버렸어여,, 거기서 수정할 부분이 있어서 추가pr 올립니당.
- json에 추가해주면 request null일때 빼고 잘보내더라구용
- 석주띠는 못본 이전 PR : https://github.com/mash-up-kr/Dorabangs_Android/pull/131


## 시연 화면 (option)
> 실행 스크린샷 혹은 영상 첨부

|기능A 구현|기능B 구현|...|
|:---|---|---|
|<img src = "" width = 400>|<img src = "" width = 400>|...|

## To Reviers
> 리뷰어들에게 전할 말

-땡큐베리망치.

## Close
close #