### PR TITLE
[feature] 공통화 및 aab 추가, 병렬 실행

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -11,6 +11,8 @@ jobs:
     secrets: inherit
 
   build:
+    env:
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '3'
     needs: common_setup
     runs-on: ubuntu-latest
     steps:
@@ -20,7 +22,7 @@ jobs:
         with:
           java-version: '18'
           distribution: 'temurin'
-          cache: gradle
+          cache: 'gradle'
       - name: Download common setup files
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -6,10 +6,13 @@ on:
     branches: [ "feature**", "hotfix**", "release**", "develop**", "master" ]
 
 jobs:
+  common_setup:
+    uses: ./.github/workflows/common-setup.yaml
+    secrets: inherit
+
   build:
-
+    needs: common_setup
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK 18
@@ -18,33 +21,10 @@ jobs:
           java-version: '18'
           distribution: 'temurin'
           cache: gradle
-
-      - name: Cache Gradle Packages
-        uses: actions/cache@v3
+      - name: Download common setup files
+        uses: actions/download-artifact@v4
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties', '**/buildSrc/**/*.kt') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-        
-      - name: Create Google Json file
-        run: cat /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/google-services.json | base64
-        
-      - name: Putting Json data
-        env:
-          DATA: ${{ secrets.GOOGLE_SERVICES_JSON }}
-        run: echo $DATA > /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/google-services.json
-        
-      - name: Access SERVER_BASE_URL
-        run:  |
-          echo server_base_url=\"$API_KEY\" > local.properties
-        shell: bash
-        env: 
-          API_KEY: ${{ secrets.SERVER_BASE_URL }}
-          
+          name: common-setup-files
+
       - name: Build with Gradle
         run: ./gradlew assembleDebug

--- a/.github/workflows/common-setup.yaml
+++ b/.github/workflows/common-setup.yaml
@@ -1,0 +1,33 @@
+name: Common Setup
+
+on: workflow_call
+
+jobs:
+  setup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Create Google Json file
+        run: cat /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/google-services.json | base64
+
+      - name: Putting Json data
+        env:
+          DATA: ${{ secrets.GOOGLE_SERVICES_JSON }}
+        run: echo $DATA > /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/google-services.json
+
+      - name: Access SERVER_BASE_URL
+        run: |
+          echo server_base_url=\"${{ secrets.SERVER_BASE_URL }}\" > local.properties
+        shell: bash
+
+      - name: Upload setup artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: common-setup-files
+          path: |
+            /home/runner/work/Dorabangs_Android/Dorabangs_Android/local.properties
+            /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/google-services.json

--- a/.github/workflows/create_artifact.yaml
+++ b/.github/workflows/create_artifact.yaml
@@ -9,9 +9,13 @@ on:
       - opened
 
 jobs:
-  create_artifact:
-    runs-on: ubuntu-latest
+  common_setup:
+    uses: ./.github/workflows/common-setup.yaml
+    secrets: inherit
 
+  upload_apk:
+    needs: common_setup
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK 18
@@ -21,28 +25,15 @@ jobs:
           distribution: 'temurin'
           cache: gradle
 
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
+      - name: Download common setup files
+        uses: actions/download-artifact@v4
+        with:
+          name: common-setup-files
 
-      - name: Create Google Json file
-        run: cat /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/google-services.json | base64
-
-      - name: Putting Json data
-        env:
-          DATA: ${{ secrets.GOOGLE_SERVICES_JSON }}
-        run: echo $DATA > /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/google-services.json
-
-      - name: Access SERVER_BASE_URL
-        run: |
-          echo server_base_url=\"$API_KEY\" > local.properties
-        shell: bash
-        env:
-          API_KEY: ${{ secrets.SERVER_BASE_URL }}
-
-      - name: Build with assembleRelease
+      - name: Build with assembleRelease for apk
         run: ./gradlew assembleRelease
 
-      - name: upload artifact
+      - name: upload artifact with apk
         uses: actions/upload-artifact@v4
         with:
           name: dora-artifact.apk
@@ -50,11 +41,56 @@ jobs:
           retention-days: 7
           overwrite: true
 
-  post_github:
-    needs: create_artifact
+  upload_aab:
+    needs: common_setup
     runs-on: ubuntu-latest
     steps:
-      - name: Get artifact ID
+      - uses: actions/checkout@v4
+      - name: set up JDK 18
+        uses: actions/setup-java@v3
+        with:
+          java-version: '18'
+          distribution: 'temurin'
+          cache: gradle
+      - name: Download common setup files
+        uses: actions/download-artifact@v4
+        with:
+          name: common-setup-files
+
+      - name: Decode release key
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'dorabangsKey.keystore'
+          fileDir: '/home/runner/work/Dorabangs_Android/Dorabangs_Android/android'
+          encodedString: ${{ secrets.RELEASE_KEYSTORE }}
+
+      - name: Build with bundleRelease for aab
+        run: ./gradlew bundleRelease
+
+      - name: sign aab
+        id: sign_app
+        uses: r0adkll/sign-android-release@v1.0.4
+        with:
+          releaseDirectory: /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/build/outputs/bundle/release
+          signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE }}
+          alias: ${{ secrets.RELEASE_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.RELEASE_KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.RELEASE_KEY_PASSWORD }}
+
+      - name: upload artifact with aab
+        uses: actions/upload-artifact@v4
+        with:
+          name: dora-artifact.aab
+          path: ./app/build/outputs/bundle/release
+          retention-days: 7
+          overwrite: true
+
+  post_github:
+    needs: [ upload_apk, upload_aab ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get artifact ID for apk
         id: get-artifact-id
         run: |
           artifact_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
@@ -62,12 +98,21 @@ jobs:
             jq -r '.artifacts[] | select(.name == "dora-artifact.apk") | .id')
           echo "artifact_id=${artifact_id}" >> $GITHUB_ENV
 
+      - name: Get artifact ID for AAB
+        id: get-artifact-id-aab
+        run: |
+          artifact_id=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+            "https://api.github.com/repos/${{ github.repository }}/actions/runs/${{ github.run_id }}/artifacts" | \
+            jq -r '.artifacts[] | select(.name == "dora-artifact.aab") | .id')
+          echo "artifact_id_aab=${artifact_id}" >> $GITHUB_ENV
+
       - name: Post comment with artifact link
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7.0.1
         with:
           script: |
-            const artifact_url = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}/artifacts/${process.env.artifact_id}`;
-            const comment_body = `APK 생성 성공했 도라 :kissing_smiling_eyes:: [APK Download Link](${artifact_url})`;
+            const artifact_url_apk = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}/artifacts/${process.env.artifact_id}`;
+            const artifact_url_aab = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}/artifacts/${process.env.artifact_id_aab}`;
+            const comment_body = `Artifact 생성 성공했 도라 :kissing_smiling_eyes:: [APK Download Link](${artifact_url_apk}), [AAB Downloads Link](${artifact_url_aab})`;
             const pull_request_number = context.issue.number;
             await github.rest.issues.createComment({
               ...context.repo,

--- a/.github/workflows/create_artifact.yaml
+++ b/.github/workflows/create_artifact.yaml
@@ -31,8 +31,26 @@ jobs:
         with:
           name: common-setup-files
 
+      - name: Decode release key
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'dorabangsKey.keystore'
+          fileDir: '/home/runner/work/Dorabangs_Android/Dorabangs_Android/android'
+          encodedString: ${{ secrets.RELEASE_KEYSTORE }}
+
       - name: Build with assembleRelease for apk
         run: ./gradlew assembleRelease
+
+      - name: sign apk
+        id: sign_app
+        uses: r0adkll/sign-android-release@v1.0.4
+        with:
+          releaseDirectory: /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/build/outputs/apk/release
+          signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE }}
+          alias: ${{ secrets.RELEASE_KEY_ALIAS }}
+          keyStorePassword: ${{ secrets.RELEASE_KEY_STORE_PASSWORD }}
+          keyPassword: ${{ secrets.RELEASE_KEY_PASSWORD }}
 
       - name: upload artifact with apk
         uses: actions/upload-artifact@v4
@@ -58,13 +76,13 @@ jobs:
         with:
           name: common-setup-files
 
-#      - name: Decode release key
-#        id: decode_keystore
-#        uses: timheuer/base64-to-file@v1.2
-#        with:
-#          fileName: 'dorabangsKey.keystore'
-#          fileDir: '/home/runner/work/Dorabangs_Android/Dorabangs_Android/android'
-#          encodedString: ${{ secrets.RELEASE_KEYSTORE }}
+      - name: Decode release key
+        id: decode_keystore
+        uses: timheuer/base64-to-file@v1.2
+        with:
+          fileName: 'dorabangsKey.keystore'
+          fileDir: '/home/runner/work/Dorabangs_Android/Dorabangs_Android/android'
+          encodedString: ${{ secrets.RELEASE_KEYSTORE }}
 
       - name: Build with bundleRelease for aab
         run: ./gradlew bundleRelease

--- a/.github/workflows/create_artifact.yaml
+++ b/.github/workflows/create_artifact.yaml
@@ -25,7 +25,7 @@ jobs:
         with:
           distribution: 'temurin'
           java-version: '18'
-          cache: gradle
+          cache: 'gradle'
 
       - name: Download common setup files
         uses: actions/download-artifact@v4
@@ -67,7 +67,7 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '18'
-          cache: gradle
+          cache: 'gradle'
       - name: Download common setup files
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/create_artifact.yaml
+++ b/.github/workflows/create_artifact.yaml
@@ -4,7 +4,6 @@ on:
   pull_request:
     branches:
       - master
-      - develop2
     types:
       - synchronize
       - opened

--- a/.github/workflows/create_artifact.yaml
+++ b/.github/workflows/create_artifact.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - master
+      - develop2
     types:
       - synchronize
       - opened
@@ -57,13 +58,13 @@ jobs:
         with:
           name: common-setup-files
 
-      - name: Decode release key
-        id: decode_keystore
-        uses: timheuer/base64-to-file@v1.2
-        with:
-          fileName: 'dorabangsKey.keystore'
-          fileDir: '/home/runner/work/Dorabangs_Android/Dorabangs_Android/android'
-          encodedString: ${{ secrets.RELEASE_KEYSTORE }}
+#      - name: Decode release key
+#        id: decode_keystore
+#        uses: timheuer/base64-to-file@v1.2
+#        with:
+#          fileName: 'dorabangsKey.keystore'
+#          fileDir: '/home/runner/work/Dorabangs_Android/Dorabangs_Android/android'
+#          encodedString: ${{ secrets.RELEASE_KEYSTORE }}
 
       - name: Build with bundleRelease for aab
         run: ./gradlew bundleRelease

--- a/.github/workflows/create_artifact.yaml
+++ b/.github/workflows/create_artifact.yaml
@@ -31,14 +31,6 @@ jobs:
         with:
           name: common-setup-files
 
-      - name: Decode release key
-        id: decode_keystore
-        uses: timheuer/base64-to-file@v1.2
-        with:
-          fileName: 'dorabangsKey.keystore'
-          fileDir: '/home/runner/work/Dorabangs_Android/Dorabangs_Android/android'
-          encodedString: ${{ secrets.RELEASE_KEYSTORE }}
-
       - name: Build with assembleRelease for apk
         run: ./gradlew assembleRelease
 
@@ -47,7 +39,7 @@ jobs:
         uses: r0adkll/sign-android-release@v1.0.4
         with:
           releaseDirectory: app/build/outputs/apk/release
-          signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE }}
+          signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE_JKS }}
           alias: ${{ secrets.RELEASE_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.RELEASE_KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.RELEASE_KEY_PASSWORD }}
@@ -78,14 +70,6 @@ jobs:
         with:
           name: common-setup-files
 
-      - name: Decode release key
-        id: decode_keystore
-        uses: timheuer/base64-to-file@v1.2
-        with:
-          fileName: 'dorabangsKey.keystore'
-          fileDir: '/home/runner/work/Dorabangs_Android/Dorabangs_Android/android'
-          encodedString: ${{ secrets.RELEASE_KEYSTORE }}
-
       - name: Build with bundleRelease for aab
         run: ./gradlew bundleRelease
 
@@ -94,7 +78,7 @@ jobs:
         uses: r0adkll/sign-android-release@v1.0.4
         with:
           releaseDirectory: app/build/outputs/bundle/release
-          signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE }}
+          signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE_JKS }}
           alias: ${{ secrets.RELEASE_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.RELEASE_KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.RELEASE_KEY_PASSWORD }}

--- a/.github/workflows/create_artifact.yaml
+++ b/.github/workflows/create_artifact.yaml
@@ -46,11 +46,13 @@ jobs:
         id: sign_app
         uses: r0adkll/sign-android-release@v1.0.4
         with:
-          releaseDirectory: /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/build/outputs/apk/release
+          releaseDirectory: app/build/outputs/apk/release
           signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE }}
           alias: ${{ secrets.RELEASE_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.RELEASE_KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.RELEASE_KEY_PASSWORD }}
+        env:
+          BUILD_TOOLS_VERSION: "34.0.0"
 
       - name: upload artifact with apk
         uses: actions/upload-artifact@v4
@@ -91,7 +93,7 @@ jobs:
         id: sign_app
         uses: r0adkll/sign-android-release@v1.0.4
         with:
-          releaseDirectory: /home/runner/work/Dorabangs_Android/Dorabangs_Android/app/build/outputs/bundle/release
+          releaseDirectory: app/build/outputs/bundle/release
           signingKeyBase64: ${{ secrets.RELEASE_KEYSTORE }}
           alias: ${{ secrets.RELEASE_KEY_ALIAS }}
           keyStorePassword: ${{ secrets.RELEASE_KEY_STORE_PASSWORD }}

--- a/.github/workflows/create_artifact.yaml
+++ b/.github/workflows/create_artifact.yaml
@@ -16,14 +16,16 @@ jobs:
 
   upload_apk:
     needs: common_setup
+    env:
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '3'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK 18
         uses: actions/setup-java@v3
         with:
-          java-version: '18'
           distribution: 'temurin'
+          java-version: '18'
           cache: gradle
 
       - name: Download common setup files
@@ -57,13 +59,15 @@ jobs:
   upload_aab:
     needs: common_setup
     runs-on: ubuntu-latest
+    env:
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '3'
     steps:
       - uses: actions/checkout@v4
       - name: set up JDK 18
         uses: actions/setup-java@v3
         with:
+          distribution: 'zulu'
           java-version: '18'
-          distribution: 'temurin'
           cache: gradle
       - name: Download common setup files
         uses: actions/download-artifact@v4

--- a/.github/workflows/lint_check.yaml
+++ b/.github/workflows/lint_check.yaml
@@ -4,6 +4,8 @@ on: pull_request
 
 jobs:
   lint-check:
+    env:
+      SEGMENT_DOWNLOAD_TIMEOUT_MINS: '3'
     runs-on: ubuntu-latest
 
     steps:
@@ -13,7 +15,7 @@ jobs:
         with:
           java-version: '18'
           distribution: 'temurin'
-          cache: gradle
+          cache: 'gradle'
 
       - name: Cache Gradle Packages
         uses: actions/cache@v3

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -44,7 +44,6 @@ android {
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard-rules.pro",
             )
-            signingConfig = signingConfigs.getByName("debug")
         }
     }
     compileOptions {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,7 +4,7 @@
 compile-sdk = "34"
 min-sdk = "28"
 target-sdk = "34"
-version-code = "2"
+version-code = "8"
 versionName = "1.0.0"
 
 agp = "8.1.3"


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약

apk 말고, aab도 생성해줍니다 - 마스터 브랜치로 pr이 생성될 때 (테스트하면서 메일 많이가서 미안합니다;;;;;)

apk랑 aab를 병렬로 생성해줍니다 (빠르게 만들게 ,,,)

apk, aab를 병렬로 만들게 하기 위해 분리를 했는데, 빌드 yaml 포함, 같은 코드를 3번이나 똑같이 써야해서 
common-setup.yaml으로 공통화했습니다

reusable workflow라는걸 처음 써봤는데, secrets을 못가져와서 한참 고생함;; (세팅을 안해주면 못가져옴,,,)


## 작업 내용
> 실제 작업 내용

상동

## To Reviers
> 리뷰어들에게 전할 말

https://github.com/actions/setup-java 공부해보기

## Close
close #