### PR TITLE
홈화면 피드 카테고리 추가 및 썸네일 radius 적용

### DIFF
--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/card/FeedCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.ui.layout.ContentScale
@@ -37,6 +38,7 @@ import com.mashup.dorabangs.core.designsystem.component.chips.FeedUiModel.FeedCa
 import com.mashup.dorabangs.core.designsystem.component.chips.FeedUiModel.FeedCardUiModel.Companion.convertCreatedSecond
 import com.mashup.dorabangs.core.designsystem.component.util.thenIf
 import com.mashup.dorabangs.core.designsystem.theme.DoraColorTokens
+import com.mashup.dorabangs.core.designsystem.theme.DoraRoundTokens
 import com.mashup.dorabangs.core.designsystem.theme.DoraTypoTokens
 import kotlinx.coroutines.delay
 
@@ -91,6 +93,7 @@ fun FeedCard(
                 modifier = Modifier
                     .size(size = 80.dp)
                     .aspectRatio(1f)
+                    .clip(DoraRoundTokens.Round4)
                     .background(color = DoraColorTokens.G1),
                 model = cardInfo.thumbnail,
                 error = painterResource(id = R.drawable.default_thumbnail),

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/model/PostResponseModel.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/model/PostResponseModel.kt
@@ -50,6 +50,7 @@ fun PostResponseModel.toDomain(): Post {
         description = description,
         isFavorite = isFavorite,
         createdAt = createdAt,
+        keywords = keywords.map { it.toDomain() },
         thumbnailImgUrl = thumbnailImgUrl,
         aiStatus = aiStatus.toDomain(),
         readAt = readAt,

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/model/MapperExtensions.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/model/MapperExtensions.kt
@@ -13,7 +13,7 @@ fun Post.toUiModel(category: String?): FeedUiModel.FeedCardUiModel {
         content = this.description,
         category = category.orEmpty(),
         createdAt = this.createdAt,
-        keywordList = listOf(),
+        keywordList = this.keywords?.map { it.name },
         isFavorite = isFavorite,
         thumbnail = thumbnailImgUrl,
         url = this.url,

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/PostCardMapper.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/PostCardMapper.kt
@@ -30,7 +30,7 @@ fun Post.toUiModel(): FeedUiModel.FeedCardUiModel {
         title = this.title,
         content = this.description,
         createdAt = this.createdAt,
-        keywordList = listOf(),
+        keywordList = this.keywords?.map { it.name },
         isFavorite = isFavorite,
         thumbnail = this.thumbnailImgUrl,
         folderId = this.folderId,


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약
- 홈화면 피드 카테고리 추가 및 썸네일 radius 적용

## 작업 내용
> 실제 작업 내용
- 홈화면 피드 카테고리 추가 및 썸네일 radius 적용했어요~
- Post모델쪽 키워드 아예 빠져있었음ㅠㅠㅠ

## 시연 화면 (option)
> 실행 스크린샷 혹은 영상 첨부
<img width="267" alt="스크린샷 2024-08-27 오전 12 27 11" src="https://github.com/user-attachments/assets/4bd50ef6-2715-4ec8-b53e-44525a8b30a1">

## To Reviers
> 리뷰어들에게 전할 말
- 응아치우기 완료

## Close
close #178 