### PR TITLE
[feature] 딱히 세팅해주지 않아도 자동으로 올라가는 버전코드

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -13,18 +13,6 @@ plugins {
 android {
     namespace = "com.mashup.dorabangs"
     compileSdk = libs.versions.compile.sdk.get().toInt()
-    fun getGitCommitCount(): Int {
-        return try {
-            val stdout = ByteArrayOutputStream()
-            exec {
-                commandLine = listOf("git", "rev-list", "--count", "HEAD")
-                standardOutput = stdout
-            }
-            stdout.toString().trim().toInt()
-        } catch (e: Exception) {
-            1 // 예외가 발생할 경우 기본값으로 1을 반환
-        }
-    }
 
     val gitCommitCount = getGitCommitCount()
 
@@ -117,4 +105,17 @@ dependencies {
 
     // Firebase
     implementation(platform(libs.firebase.bom))
+}
+
+fun getGitCommitCount(): Int {
+    return try {
+        val stdout = ByteArrayOutputStream()
+        exec {
+            commandLine = listOf("git", "rev-list", "--count", "HEAD")
+            standardOutput = stdout
+        }
+        stdout.toString().trim().toInt()
+    } catch (e: Exception) {
+        1 // 예외가 발생할 경우 기본값으로 1을 반환
+    }
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -107,15 +107,17 @@ dependencies {
     implementation(platform(libs.firebase.bom))
 }
 
+/**
+ * 일단 defaultValue를 1로 주어, 익셉션시에 1로 세팅되겠지만,
+ * 앱은 못올릴 것 (1은 중복이라)
+ */
 fun getGitCommitCount(): Int {
-    return try {
+    return runCatching {
         val stdout = ByteArrayOutputStream()
         exec {
             commandLine = listOf("git", "rev-list", "--count", "HEAD")
             standardOutput = stdout
         }
         stdout.toString().trim().toInt()
-    } catch (e: Exception) {
-        1 // 예외가 발생할 경우 기본값으로 1을 반환
-    }
+    }.getOrDefault(1)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,3 @@
-import java.io.ByteArrayOutputStream
 
 @Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
@@ -14,13 +13,11 @@ android {
     namespace = "com.mashup.dorabangs"
     compileSdk = libs.versions.compile.sdk.get().toInt()
 
-    val gitCommitCount = getGitCommitCount()
-
     defaultConfig {
         applicationId = "com.mashup.dorabangs"
         minSdk = libs.versions.min.sdk.get().toInt()
         targetSdk = libs.versions.target.sdk.get().toInt()
-        versionCode = gitCommitCount
+        versionCode = GitUtil.getGitCommitCount(project)
         versionName = libs.versions.versionName.get()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
@@ -105,19 +102,4 @@ dependencies {
 
     // Firebase
     implementation(platform(libs.firebase.bom))
-}
-
-/**
- * 일단 defaultValue를 1로 주어, 익셉션시에 1로 세팅되겠지만,
- * 앱은 못올릴 것 (1은 중복이라)
- */
-fun getGitCommitCount(): Int {
-    return runCatching {
-        val stdout = ByteArrayOutputStream()
-        exec {
-            commandLine = listOf("git", "rev-list", "--count", "HEAD")
-            standardOutput = stdout
-        }
-        stdout.toString().trim().toInt()
-    }.getOrDefault(1)
 }

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import java.io.ByteArrayOutputStream
+
 @Suppress("DSL_SCOPE_VIOLATION") // TODO: Remove once KTIJ-19369 is fixed
 plugins {
     alias(libs.plugins.com.android.application)
@@ -11,12 +13,26 @@ plugins {
 android {
     namespace = "com.mashup.dorabangs"
     compileSdk = libs.versions.compile.sdk.get().toInt()
+    fun getGitCommitCount(): Int {
+        return try {
+            val stdout = ByteArrayOutputStream()
+            exec {
+                commandLine = listOf("git", "rev-list", "--count", "HEAD")
+                standardOutput = stdout
+            }
+            stdout.toString().trim().toInt()
+        } catch (e: Exception) {
+            1 // 예외가 발생할 경우 기본값으로 1을 반환
+        }
+    }
+
+    val gitCommitCount = getGitCommitCount()
 
     defaultConfig {
         applicationId = "com.mashup.dorabangs"
         minSdk = libs.versions.min.sdk.get().toInt()
         targetSdk = libs.versions.target.sdk.get().toInt()
-        versionCode = libs.versions.version.code.get().toInt()
+        versionCode = gitCommitCount
         versionName = libs.versions.versionName.get()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -1,0 +1,9 @@
+import org.gradle.kotlin.dsl.`kotlin-dsl`
+
+plugins {
+    `kotlin-dsl`
+}
+repositories {
+    google()
+    mavenCentral()
+}

--- a/buildSrc/src/main/kotlin/GitUtil.kt
+++ b/buildSrc/src/main/kotlin/GitUtil.kt
@@ -1,0 +1,20 @@
+import java.io.ByteArrayOutputStream
+import org.gradle.api.Project
+
+object GitUtil {
+    /**
+     * 익셉션 나오면 1로 세팅돼서
+     * aab 업로드시에 버전이 겹치다고 나올 것임
+     * 그 때 default를 바꾸던,,익셉션 안나게 하던,,, 잘 해보도록 해~
+     */
+    fun getGitCommitCount(project: Project): Int {
+        return runCatching {
+            val stdout = ByteArrayOutputStream()
+            project.exec {
+                commandLine = listOf("git", "rev-list", "--count", "HEAD")
+                standardOutput = stdout
+            }
+            stdout.toString().trim().toInt()
+        }.getOrDefault(1)
+    }
+}


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약

커밋 개수로 판단합니다. 제가 저번에 봤던 바로는 버전 코드는 21억까지 가능함 
거짓말아니고 진짜로,, 

커밋 21억까지 가능하면 반대 가능

+ BuildSrc 추가해서 거기서 버전관리하는 함수 써용

## 작업 내용
> 실제 작업 내용

커밋 개수 == 버전 코드

![image](https://github.com/user-attachments/assets/d2b615f1-5579-441b-bee9-d637a3be12b2)
