### PR TITLE
[refactoring] ksp로 변경함

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,7 +4,7 @@ plugins {
     alias(libs.plugins.com.android.application)
     alias(libs.plugins.org.jetbrains.kotlin.android)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinx.serialization)
     alias(libs.plugins.google.gms.service)
 }
@@ -101,7 +101,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     // Firebase
     implementation(platform(libs.firebase.bom))

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -55,7 +55,7 @@ android {
         targetCompatibility = JavaVersion.VERSION_18
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.4"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
     kotlinOptions {
         jvmTarget = "18"

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,8 +7,8 @@ plugins {
     alias(libs.plugins.org.jetbrains.kotlin.jvm) apply false
     alias(libs.plugins.spotless) apply true
     alias(libs.plugins.hilt) apply false
-    alias(libs.plugins.kotlin.kapt) apply false
     alias(libs.plugins.google.gms.service) apply false
+    alias(libs.plugins.ksp) apply false
 }
 
 subprojects {

--- a/core/designsystem/build.gradle.kts
+++ b/core/designsystem/build.gradle.kts
@@ -17,7 +17,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_18

--- a/core/webview/build.gradle.kts
+++ b/core/webview/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -64,7 +64,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
     implementation(libs.compose.webview)
 }

--- a/core/webview/build.gradle.kts
+++ b/core/webview/build.gradle.kts
@@ -30,7 +30,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
 
     compileOptions {

--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
     id("jacoco")
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
     alias(libs.plugins.kotlinx.serialization)
 }
@@ -121,7 +121,7 @@ dependencies {
     implementation(libs.retrofit)
 
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
 
     testImplementation(libs.junit)
     testImplementation(libs.mockk)
@@ -152,7 +152,7 @@ dependencies {
     implementation(libs.room.runtime)
     implementation(libs.room.paging)
     implementation(libs.room.ktx)
-    kapt(libs.room.compiler)
+    ksp(libs.room.compiler)
 
     implementation(libs.gson)
 

--- a/feature/classification/build.gradle.kts
+++ b/feature/classification/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -68,7 +68,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // Orbit

--- a/feature/classification/build.gradle.kts
+++ b/feature/classification/build.gradle.kts
@@ -30,7 +30,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
 
     compileOptions {

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
 
     compileOptions {

--- a/feature/home/build.gradle.kts
+++ b/feature/home/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -59,7 +59,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // Orbit

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -56,7 +56,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // Orbit

--- a/feature/onboarding/build.gradle.kts
+++ b/feature/onboarding/build.gradle.kts
@@ -19,7 +19,7 @@ android {
     }
 
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
 
     compileOptions {

--- a/feature/save/build.gradle.kts
+++ b/feature/save/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
 
     compileOptions {

--- a/feature/save/build.gradle.kts
+++ b/feature/save/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -59,7 +59,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // Orbit

--- a/feature/share/build.gradle.kts
+++ b/feature/share/build.gradle.kts
@@ -3,7 +3,7 @@ plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
 }
 
 android {
@@ -72,7 +72,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // Orbit

--- a/feature/share/build.gradle.kts
+++ b/feature/share/build.gradle.kts
@@ -29,7 +29,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_18

--- a/feature/storage/build.gradle.kts
+++ b/feature/storage/build.gradle.kts
@@ -19,7 +19,7 @@ android {
         compose = true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion = "1.4.3"
+        kotlinCompilerExtensionVersion = "1.5.2"
     }
 
     compileOptions {

--- a/feature/storage/build.gradle.kts
+++ b/feature/storage/build.gradle.kts
@@ -2,7 +2,7 @@ plugins {
     alias(libs.plugins.com.android.library)
     alias(libs.plugins.org.jetbrains.kotlin.android)
     alias(libs.plugins.hilt)
-    alias(libs.plugins.kotlin.kapt)
+    alias(libs.plugins.ksp)
     alias(libs.plugins.kotlinx.serialization)
 }
 
@@ -57,7 +57,7 @@ dependencies {
 
     // Hilt
     implementation(libs.hilt.android)
-    kapt(libs.hilt.compiler)
+    ksp(libs.hilt.compiler)
     implementation(libs.hilt.navigation.compose)
 
     // Orbit

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -8,6 +8,7 @@ versionName = "1.0.3"
 
 agp = "8.1.3"
 org-jetbrains-kotlin-android = "1.9.0"
+org-jetbrains-kotlin-jvm = "1.9.0"
 coil = "2.6.0"
 core-ktx = "1.13.1"
 junit = "4.13.2"
@@ -19,11 +20,10 @@ compose-bom = "2024.06.00"
 appcompat = "1.6.1"
 material3 = "1.2.1"
 material = "1.12.0"
-org-jetbrains-kotlin-jvm = "1.9.0"
 splash = "1.0.1"
 spotless = "6.19.0"
 mockk = "1.13.10"
-kotlin = "1.8.0"
+kotlinx = "1.8.0"
 okhttp = "4.12.0"
 retrofit = "2.9.0"
 hilt = "2.51.1"
@@ -52,9 +52,9 @@ ksp = "1.9.0-1.0.12"
 
 
 [libraries]
-kotlin-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlin" }
-kotlin-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlin" }
-kotlin-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlin" }
+kotlin-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "kotlinx" }
+kotlin-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "kotlinx" }
+kotlin-android = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-android", version.ref = "kotlinx" }
 
 lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle-runtime-ktx" }
 lifecycle-compose-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-compose", version.ref = "lifecycle-runtime-ktx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -48,6 +48,7 @@ exoplayer = "1.3.1"
 compose-webview = "0.31.3-beta"
 room = "2.6.1"
 gson = "2.10.1"
+ksp = "1.8.10-1.0.9"
 
 
 [libraries]
@@ -145,9 +146,9 @@ com-android-library = { id = "com.android.library", version.ref = "agp" }
 org-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "org-jetbrains-kotlin-jvm" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-gms-service = { id = "com.google.gms.google-services", version.ref = "gms" }
+ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 
 [bundles]
 okhttp = ["okhttp", "okhttp-logging-interceptor"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,7 @@ target-sdk = "34"
 versionName = "1.0.3"
 
 agp = "8.1.3"
-org-jetbrains-kotlin-android = "1.8.10"
+org-jetbrains-kotlin-android = "1.9.0"
 coil = "2.6.0"
 core-ktx = "1.13.1"
 junit = "4.13.2"
@@ -19,7 +19,7 @@ compose-bom = "2024.06.00"
 appcompat = "1.6.1"
 material3 = "1.2.1"
 material = "1.12.0"
-org-jetbrains-kotlin-jvm = "1.8.10"
+org-jetbrains-kotlin-jvm = "1.9.0"
 splash = "1.0.1"
 spotless = "6.19.0"
 mockk = "1.13.10"
@@ -48,7 +48,7 @@ exoplayer = "1.3.1"
 compose-webview = "0.31.3-beta"
 room = "2.6.1"
 gson = "2.10.1"
-ksp = "1.8.10-1.0.9"
+ksp = "1.9.0-1.0.12"
 
 
 [libraries]
@@ -146,7 +146,7 @@ com-android-library = { id = "com.android.library", version.ref = "agp" }
 org-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "org-jetbrains-kotlin-jvm" }
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
-kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinx-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin-serialization" }
 google-gms-service = { id = "com.google.gms.google-services", version.ref = "gms" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약

kapt 제거, ksp 사용했슴다. 데이터 바인딩 안쓰니 마이그레이션 안할 이유가 없슴

kapt는 java annotation processor를 이용해서 어노테이션 사용하게 가능 이때 스텁이란걸 만드는데 이게 빌드 속도에 영향줌
ksp는 그런 스텁없이 코틀린 코드를 직접 분석해서 빌드 속도가 빠름

kapt를 쓰면 kaptGenerateStubsDebugKotlin 라는 작업이 있고
ksp를 쓰면 kaptGenerateStubsDebugKotlin 작업이 없대요 아래 블로그 참고 

![image](https://github.com/user-attachments/assets/f01e946a-1dc6-4986-87f4-b4513777fcfe)

https://developer.android.com/build/migrate-to-ksp?hl=ko
https://fall-in-it.tistory.com/58

## 작업 내용
> 실제 작업 내용

1. kapt 제거, ksp 사용
2. ksp사용하려니 dagger를 지원하는 1.9.0-1.0.12 버전을 써야함
3. 앞에 있는 1.9.0 == 코틀린 버전이라서, 코틀린 버전도 1.9.0으로 올림
4. 그러다 보니 코틀린 버전이랑 맞는 컴포즈 컴파일러 버전(1.9.0 -> 1.5.2) 로 변경
![image](https://github.com/user-attachments/assets/cbfe0f55-2972-44b1-8ce1-0290548b6439)
https://developer.android.com/jetpack/androidx/releases/compose-kotlin

## To Reviers
> 리뷰어들에게 전할 말

kotlin 쓰면서 데바 안쓰니 ksp로 바꿨습니다
