### PR TITLE
[#128] 필터 칩 고를때, filter 거는게 아닌 api 새로 호출 

### DIFF
--- a/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/api/AIClassificationRemoteDataSource.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/api/AIClassificationRemoteDataSource.kt
@@ -2,7 +2,6 @@ package com.mashup.dorabangs.data.datasource.remote.api
 
 import com.mashup.dorabangs.data.model.classification.AIClassificationAIPostListResponseModel
 import com.mashup.dorabangs.domain.model.AIClassificationFolders
-import com.mashup.dorabangs.domain.model.AIClassificationPosts
 
 interface AIClassificationRemoteDataSource {
 

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/api/AIClassificationRemoteDataSource.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/api/AIClassificationRemoteDataSource.kt
@@ -23,7 +23,7 @@ interface AIClassificationRemoteDataSource {
         page: Int? = null,
         limit: Int? = null,
         order: String? = null,
-    ): AIClassificationPosts
+    ): AIClassificationAIPostListResponseModel
 
     suspend fun deletePostFromAIClassification(
         postId: String,

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/AIClassificationRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/AIClassificationRemoteDataSourceImpl.kt
@@ -38,13 +38,13 @@ class AIClassificationRemoteDataSourceImpl @Inject constructor(
         page: Int?,
         limit: Int?,
         order: String?,
-    ): AIClassificationPosts =
+    ): AIClassificationAIPostListResponseModel =
         service.getAIClassificationPostsByFolder(
             folderId = folderId,
             page = page,
             limit = limit,
             order = order,
-        ).toDomain()
+        )
 
     override suspend fun deletePostFromAIClassification(postId: String) =
         service.deletePostFromAIClassification(

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/AIClassificationRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/datasource/remote/impl/AIClassificationRemoteDataSourceImpl.kt
@@ -6,7 +6,6 @@ import com.mashup.dorabangs.data.model.classification.AIClassificationAIPostList
 import com.mashup.dorabangs.data.model.toDomain
 import com.mashup.dorabangs.data.network.service.AIClassificationService
 import com.mashup.dorabangs.domain.model.AIClassificationFolders
-import com.mashup.dorabangs.domain.model.AIClassificationPosts
 import javax.inject.Inject
 
 class AIClassificationRemoteDataSourceImpl @Inject constructor(

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/network/service/AIClassificationService.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/network/service/AIClassificationService.kt
@@ -1,7 +1,6 @@
 package com.mashup.dorabangs.data.network.service
 
 import com.mashup.dorabangs.data.model.AIClassificationFoldersResponseModel
-import com.mashup.dorabangs.data.model.AIClassificationPostsResponseModel
 import com.mashup.dorabangs.data.model.AiClassificationMoveSinglePostRequestModel
 import com.mashup.dorabangs.data.model.classification.AIClassificationAIPostListResponseModel
 import retrofit2.http.Body

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/network/service/AIClassificationService.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/network/service/AIClassificationService.kt
@@ -40,7 +40,7 @@ interface AIClassificationService {
         @Query("page") page: Int? = null,
         @Query("limit") limit: Int? = null,
         @Query("order") order: String? = null,
-    ): AIClassificationPostsResponseModel
+    ): AIClassificationAIPostListResponseModel
 
     @DELETE("classification/posts/{postId}")
     suspend fun deletePostFromAIClassification(

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/repository/AIClassificationRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/repository/AIClassificationRepositoryImpl.kt
@@ -5,7 +5,6 @@ import com.mashup.dorabangs.data.datasource.remote.api.AIClassificationRemoteDat
 import com.mashup.dorabangs.data.model.classification.toPagingDomain
 import com.mashup.dorabangs.data.utils.doraPager
 import com.mashup.dorabangs.domain.model.AIClassificationFolders
-import com.mashup.dorabangs.domain.model.AIClassificationPosts
 import com.mashup.dorabangs.domain.model.DoraSampleResponse
 import com.mashup.dorabangs.domain.model.classification.AIClassificationFeedPost
 import com.mashup.dorabangs.domain.repository.AIClassificationRepository

--- a/data/src/main/kotlin/com/mashup/dorabangs/data/repository/AIClassificationRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/mashup/dorabangs/data/repository/AIClassificationRepositoryImpl.kt
@@ -44,16 +44,19 @@ class AIClassificationRepositoryImpl @Inject constructor(
 
     override suspend fun getAIClassificationPostsByFolder(
         folderId: String,
-        page: Int?,
         limit: Int?,
         order: String?,
-    ): AIClassificationPosts =
-        remoteDataSource.getAIClassificationPostsByFolder(
-            folderId = folderId,
-            page = page,
-            limit = limit,
-            order = order,
-        )
+    ): Flow<PagingData<AIClassificationFeedPost>> =
+        doraPager(
+            apiExecutor = { page ->
+                remoteDataSource.getAIClassificationPostsByFolder(
+                    folderId = folderId,
+                    page = page,
+                    limit = limit,
+                    order = order,
+                ).toPagingDomain()
+            },
+        ).flow
 
     override suspend fun deletePostFromAIClassification(postId: String): DoraSampleResponse {
         return kotlin.runCatching {

--- a/domain/src/main/kotlin/com/mashup/dorabangs/domain/repository/AIClassificationRepository.kt
+++ b/domain/src/main/kotlin/com/mashup/dorabangs/domain/repository/AIClassificationRepository.kt
@@ -22,10 +22,9 @@ interface AIClassificationRepository {
 
     suspend fun getAIClassificationPostsByFolder(
         folderId: String,
-        page: Int? = null,
         limit: Int? = null,
         order: String? = null,
-    ): AIClassificationPosts
+    ): Flow<PagingData<AIClassificationFeedPost>>
 
     suspend fun deletePostFromAIClassification(
         postId: String,

--- a/domain/src/main/kotlin/com/mashup/dorabangs/domain/repository/AIClassificationRepository.kt
+++ b/domain/src/main/kotlin/com/mashup/dorabangs/domain/repository/AIClassificationRepository.kt
@@ -2,7 +2,6 @@ package com.mashup.dorabangs.domain.repository
 
 import androidx.paging.PagingData
 import com.mashup.dorabangs.domain.model.AIClassificationFolders
-import com.mashup.dorabangs.domain.model.AIClassificationPosts
 import com.mashup.dorabangs.domain.model.DoraSampleResponse
 import com.mashup.dorabangs.domain.model.classification.AIClassificationFeedPost
 import kotlinx.coroutines.flow.Flow

--- a/domain/src/main/kotlin/com/mashup/dorabangs/domain/usecase/aiclassification/GetAIClassificationPostsByFolderUseCase.kt
+++ b/domain/src/main/kotlin/com/mashup/dorabangs/domain/usecase/aiclassification/GetAIClassificationPostsByFolderUseCase.kt
@@ -10,13 +10,11 @@ class GetAIClassificationPostsByFolderUseCase @Inject constructor(
 
     suspend operator fun invoke(
         folderId: String,
-        page: Int? = null,
         limit: Int? = null,
         order: Sort? = null,
     ) =
         aiClassificationRepository.getAIClassificationPostsByFolder(
             folderId = folderId,
-            page = page,
             limit = limit,
             order = order?.query,
         )

--- a/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationListScreen.kt
+++ b/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationListScreen.kt
@@ -55,26 +55,22 @@ fun ClassificationListScreen(
             pagingList[idx]?.let { item ->
                 when (item) {
                     is FeedUiModel.DoraChipUiModel -> {
-                        if (state.selectedFolder == item.title || state.selectedFolder == "전체") {
-                            ClassificationFolderMove(
-                                selectedFolder = item.title,
-                                onClickAllItemMoveButton = { onClickAllItemMoveButton(item.folderId) },
-                                count = item.postCount,
-                            )
-                        }
+                        ClassificationFolderMove(
+                            selectedFolder = item.title,
+                            onClickAllItemMoveButton = { onClickAllItemMoveButton(item.folderId) },
+                            count = item.postCount,
+                        )
                     }
 
                     is FeedUiModel.FeedCardUiModel -> {
-                        if (state.selectedFolder == item.category || state.selectedFolder == "전체") {
-                            ClassificationCardItem(
-                                idx = idx,
-                                lastIndex = pagingList.itemCount - 1,
-                                cardItem = item,
-                                onClickDeleteButton = onClickDeleteButton,
-                                onClickMoveButton = onClickMoveButton,
-                                onClickCardItem = onClickCardItem,
-                            )
-                        }
+                        ClassificationCardItem(
+                            idx = idx,
+                            lastIndex = pagingList.itemCount - 1,
+                            cardItem = item,
+                            onClickDeleteButton = onClickDeleteButton,
+                            onClickMoveButton = onClickMoveButton,
+                            onClickCardItem = onClickCardItem,
+                        )
                     }
                 }
             }

--- a/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationState.kt
+++ b/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationState.kt
@@ -4,7 +4,6 @@ import com.mashup.dorabangs.core.designsystem.component.chips.FeedUiModel
 
 data class ClassificationState(
     val chipState: ChipState = ChipState(),
-    val selectedFolder: String = "전체",
     val isLoading: Boolean = false,
 )
 

--- a/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
+++ b/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
@@ -215,7 +215,7 @@ class ClassificationViewModel @Inject constructor(
         intent {
             reduce {
                 state.copy(
-                    isLoading = false
+                    isLoading = false,
                 )
             }
         }
@@ -265,7 +265,9 @@ class ClassificationViewModel @Inject constructor(
             if (it is FeedUiModel.DoraChipUiModel) {
                 val updateItem = chipList.find { chip -> chip.id == it.folderId }
                 it.copy(postCount = updateItem?.postCount ?: it.postCount)
-            } else it
+            } else {
+                it
+            }
         }
     }
 

--- a/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
+++ b/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
@@ -166,9 +166,9 @@ class ClassificationViewModel @Inject constructor(
                 state.copy(isLoading = true)
             }
         }
-        val allMove = moveAllPostUseCase.invoke(suggestionFolderId = folderId)
+        val allMoveItem = moveAllPostUseCase.invoke(suggestionFolderId = folderId)
 
-        if (allMove.isSuccess) {
+        if (allMoveItem.isSuccess) {
             getInitialData()
         }
     }.invokeOnCompletion {
@@ -184,12 +184,12 @@ class ClassificationViewModel @Inject constructor(
                     isLoading = true,
                 )
             }
-            val move = moveSinglePostUseCase.invoke(
+            val moveItem = moveSinglePostUseCase.invoke(
                 postId = cardItem.postId,
                 suggestionFolderId = cardItem.folderId,
             )
 
-            if (move.isSuccess) {
+            if (moveItem.isSuccess) {
                 val (chips, chipList) = updateChipList()
                 val findCategory = chips.list.find { it.folderId == cardItem.folderId }
 
@@ -227,8 +227,8 @@ class ClassificationViewModel @Inject constructor(
                     isLoading = true,
                 )
             }
-            val delete = deletePostUseCase.invoke(cardItem.postId)
-            if (delete.isSuccess) {
+            val deleteItem = deletePostUseCase.invoke(cardItem.postId)
+            if (deleteItem.isSuccess) {
                 val (chips, chipList) = updateChipList()
                 val findCategory = chips.list.find { it.folderId == cardItem.folderId }
 

--- a/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
+++ b/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
@@ -155,7 +155,6 @@ class ClassificationViewModel @Inject constructor(
             reduce {
                 state.copy(
                     chipState = state.chipState.copy(currentIndex = idx),
-                    selectedFolder = state.chipState.chipList.getOrNull(idx)?.title ?: "전체",
                 )
             }
         }

--- a/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
+++ b/feature/classification/src/main/java/com/mashup/feature/classification/ClassificationViewModel.kt
@@ -189,7 +189,7 @@ class ClassificationViewModel @Inject constructor(
             intent {
                 reduce {
                     state.copy(
-                        chipState = ChipState(
+                        chipState = state.chipState.copy(
                             totalCount = chips.totalCounts,
                             chipList = chipList,
                         ),
@@ -208,7 +208,7 @@ class ClassificationViewModel @Inject constructor(
             intent {
                 reduce {
                     state.copy(
-                        chipState = ChipState(
+                        chipState = state.chipState.copy(
                             totalCount = chips.totalCounts,
                             chipList = chipList,
                         ),


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약

기존에는 AI 분류된 곳에서 칩을 누를 시에, 현재 리스트에서 filter를 걸어 보여줬지만,
이 경우 아직 불러오지 않은 리스트 에대한 필터링이 불가능해서 (리스트에 없기때문)

칩 누르면, 해당 리스트 서버 호출하여 새로 가져오도록 수행

## 작업 내용
> 실제 작업 내용

상동

## To Reviers
> 리뷰어들에게 전할 말

ㄷㄹㅂㅅ ㅎㅇㅌ

## Close
close #128