### PR TITLE
홈 화면 로딩 관련 개선

### DIFF
--- a/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/chips/FeedUiModel.kt
+++ b/core/designsystem/src/main/java/com/mashup/dorabangs/core/designsystem/component/chips/FeedUiModel.kt
@@ -7,6 +7,7 @@ import java.time.ZonedDateTime
 import java.time.format.DateTimeFormatter
 import java.time.temporal.ChronoUnit
 import java.util.UUID
+import com.mashup.dorabangs.core.designsystem.R as CR
 
 sealed interface FeedUiModel {
     val uuid: String
@@ -60,8 +61,21 @@ sealed interface FeedUiModel {
         val title: String = "",
         val postCount: Int = 0,
         val folderId: String = "",
-        @DrawableRes val icon: Int? = com.mashup.dorabangs.core.designsystem.R.drawable.ic_3d_all_small,
+        @DrawableRes val icon: Int? = CR.drawable.ic_3d_all_small,
     ) : FeedUiModel {
         override val uuid: String = UUID.randomUUID().toString()
+
+        companion object {
+            fun getDefaultModelList() = listOf(
+                DoraChipUiModel(
+                    title = "전체",
+                    icon = CR.drawable.ic_3d_all_small,
+                ),
+                DoraChipUiModel(
+                    title = "즐겨찾기",
+                    icon = CR.drawable.ic_3d_bookmark_small,
+                ),
+            )
+        }
     }
 }

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeContract.kt
@@ -10,7 +10,7 @@ data class HomeState(
     val isLoading: Boolean = false,
     val isScrollLoading: Boolean = false,
     val clipBoardState: ClipBoardState = ClipBoardState(),
-    val tapElements: List<FeedUiModel.DoraChipUiModel> = emptyList(),
+    val tapElements: List<FeedUiModel.DoraChipUiModel> = FeedUiModel.DoraChipUiModel.getDefaultModelList(),
     val folderList: List<Folder> = listOf(),
     val selectedIndex: Int = 0,
     val selectedPostId: String = "",

--- a/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeScreen.kt
+++ b/feature/home/src/main/java/com/mashup/dorabangs/feature/home/HomeScreen.kt
@@ -93,6 +93,7 @@ fun HomeScreen(
             ) {
                 LottieLoader(
                     lottieRes = R.raw.spinner,
+                    iterations = Int.MAX_VALUE,
                     modifier = Modifier
                         .size(54.dp)
                         .align(Alignment.Center),


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약

- 홈 화면 로딩 관련 개선

## 작업 내용
> 실제 작업 내용

- 홈 화면 로딩 lottie 무한 반복 설정
- 폴더 로딩 전 기본 폴더 보여지도록 설정

## 시연 화면 (option)
> 실행 스크린샷 혹은 영상 첨부

|로딩중인 홈화면|
|---|
|<img width="423" alt="image" src="https://github.com/user-attachments/assets/0d4b02f2-f32b-4c00-8fde-3b6e5ad508c5">|

## To Reviers
> 리뷰어들에게 전할 말

- 도라핑 화이핑
