### PR TITLE
보관함 상세 탭 디자인 수정

### DIFF
--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetail.kt
@@ -1,6 +1,7 @@
 package com.mashup.dorabangs.feature.storage.storagedetail
 
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyListState
@@ -8,7 +9,6 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -16,11 +16,9 @@ import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.zIndex
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.collectAsLazyPagingItems
@@ -40,9 +38,6 @@ import org.orbitmvi.orbit.compose.collectAsState
 import org.orbitmvi.orbit.compose.collectSideEffect
 import com.mashup.dorabangs.feature.storage.R as storageR
 
-val MinToolbarHeight = 96.dp
-val MaxToolbarHeight = 161.dp
-
 @Composable
 fun StorageDetailRoute(
     folderItem: Folder,
@@ -58,7 +53,6 @@ fun StorageDetailRoute(
     storageDetailViewModel: StorageDetailViewModel = hiltViewModel(),
 ) {
     val context = LocalContext.current
-    val overlapHeightPx = with(LocalDensity.current) { MaxToolbarHeight.toPx() - MinToolbarHeight.toPx() }
     val state by storageDetailViewModel.collectAsState()
     val toastSnackBarHostState by remember { mutableStateOf(SnackbarHostState()) }
     val scope = rememberCoroutineScope()
@@ -90,13 +84,6 @@ fun StorageDetailRoute(
         storageDetailViewModel.setVisibleMovingFolderBottomSheet(isVisibleBottomSheet)
     }
 
-    val isCollapsed: Boolean by remember {
-        derivedStateOf {
-            val isFirstItemHidden = listState.firstVisibleItemScrollOffset > overlapHeightPx
-            isFirstItemHidden || listState.firstVisibleItemIndex > 0
-        }
-    }
-
     storageDetailViewModel.collectSideEffect { sideEffect ->
         handleSideEffect(
             sideEffect = sideEffect,
@@ -113,7 +100,6 @@ fun StorageDetailRoute(
             state = state,
             linksPagingList = linksPagingList,
             listState = listState,
-            isCollapsed = isCollapsed,
             onClickBackIcon = { onClickBackIcon(state.isChangeData) },
             onClickTabItem = storageDetailViewModel::changeSelectedTabIdx,
             onClickSortedIcon = storageDetailViewModel::clickFeedSort,
@@ -239,15 +225,14 @@ fun StorageDetailScreen(
     modifier: Modifier = Modifier,
     state: StorageDetailState = StorageDetailState(),
     listState: LazyListState = rememberLazyListState(),
-    isCollapsed: Boolean = false,
 ) {
-    Box(
+    Column(
         modifier = modifier,
     ) {
-        StorageDetailCollapsingHeader(
+        StorageDetailHeader(
             state = state,
-            modifier = Modifier.zIndex(2f),
-            isCollapsed = isCollapsed,
+            chipList = state.tabInfo.tabTitleList,
+            selectedTabIdx = state.tabInfo.selectedTabIdx,
             onClickBackIcon = onClickBackIcon,
             onClickTabItem = onClickTabItem,
             onClickActionIcon = onClickActionIcon,
@@ -256,11 +241,8 @@ fun StorageDetailScreen(
             listState = listState,
             linksPagingList = linksPagingList,
             state = state,
-            onClickBackIcon = onClickBackIcon,
             onClickSortedIcon = onClickSortedIcon,
-            onClickTabItem = onClickTabItem,
             onClickBookMarkButton = onClickBookMarkButton,
-            onClickActionIcon = onClickActionIcon,
             onClickMoreButton = onClickMoreButton,
             onClickPostItem = onClickPostItem,
 

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailHeader.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailHeader.kt
@@ -1,198 +1,40 @@
 package com.mashup.dorabangs.feature.storage.storagedetail
 
-import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.Image
-import androidx.compose.foundation.background
-import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.HorizontalDivider
-import androidx.compose.material3.Text
-import androidx.compose.material3.VerticalDivider
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.res.painterResource
-import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
-import androidx.compose.ui.unit.dp
+import com.mashup.dorabangs.core.designsystem.component.chips.DoraChips
+import com.mashup.dorabangs.core.designsystem.component.chips.FeedUiModel
 import com.mashup.dorabangs.core.designsystem.component.topbar.DoraTopBar
-import com.mashup.dorabangs.core.designsystem.theme.DoraColorTokens
-import com.mashup.dorabangs.core.designsystem.theme.DoraRoundTokens
-import com.mashup.dorabangs.core.designsystem.theme.DoraTypoTokens
 import com.mashup.dorabangs.domain.model.FolderType
 import com.mashup.dorabangs.feature.storage.storagedetail.model.StorageDetailState
-import com.mashup.dorabangs.feature.storage.storagedetail.model.StorageDetailTab
-import com.mashup.dorabangs.util.getFolderIcon
 import com.mashup.dorabangs.core.designsystem.R as coreR
 
 @Composable
-fun StorageDetailCollapsingHeader(
+fun StorageDetailHeader(
     state: StorageDetailState,
-    isCollapsed: Boolean,
-    onClickBackIcon: () -> Unit,
-    onClickTabItem: (Int) -> Unit,
-    onClickActionIcon: () -> Unit,
-    modifier: Modifier = Modifier,
-) {
-    Column(
-        modifier = modifier.then(
-            Modifier
-                .background(color = DoraColorTokens.White)
-                .height(MinToolbarHeight),
-        ),
-    ) {
-        if (isCollapsed) {
-            StorageDetailTopBarByFolderType(
-                state = state,
-                isCollapsed = true,
-                onClickBackIcon = onClickBackIcon,
-                onClickActionIcon = onClickActionIcon,
-            )
-            StorageDetailHeaderTabBar(
-                tabList = state.tabInfo.tabTitleList,
-                onClickTabItem = onClickTabItem,
-                selectedTabIdx = state.tabInfo.selectedTabIdx,
-            )
-        }
-    }
-}
-
-@Composable
-fun StorageDetailExpandedHeader(
-    state: StorageDetailState,
+    chipList: List<FeedUiModel.DoraChipUiModel>,
+    selectedTabIdx: Int = 0,
     onClickTabItem: (Int) -> Unit,
     onClickBackIcon: () -> Unit,
-    onClickActionIcon: () -> Unit,
     modifier: Modifier = Modifier,
+    onClickActionIcon: () -> Unit = {},
 ) {
     Column(
-        modifier = modifier.height(MaxToolbarHeight),
+        modifier = modifier.fillMaxWidth(),
     ) {
         StorageDetailTopBarByFolderType(
             state = state,
-            isCollapsed = false,
-            onClickBackIcon = onClickBackIcon,
             onClickActionIcon = onClickActionIcon,
+            onClickBackIcon = onClickBackIcon,
         )
-        StorageDetailHeaderContent(
-            state = state,
-        )
-        StorageDetailHeaderTabBar(
-            tabList = state.tabInfo.tabTitleList,
-            selectedTabIdx = state.tabInfo.selectedTabIdx,
-            onClickTabItem = onClickTabItem,
-        )
-        Box(
-            modifier = Modifier
-                .fillMaxWidth()
-                .height(0.5.dp)
-                .background(DoraColorTokens.G2),
-        )
-    }
-}
-
-@Composable
-fun StorageDetailHeaderContent(
-    state: StorageDetailState,
-    modifier: Modifier = Modifier,
-) {
-    Row(
-        modifier = modifier
-            .fillMaxWidth()
-            .height(64.dp)
-            .background(color = DoraColorTokens.P1)
-            .padding(horizontal = 20.dp, vertical = 6.dp),
-    ) {
-        Box(
-            modifier = Modifier.background(
-                color = DoraColorTokens.G1,
-                shape = DoraRoundTokens.Round8,
-            )
-                .size(54.dp),
-        ) {
-            Image(
-                modifier = Modifier
-                    .padding(6.dp)
-                    .size(40.dp)
-                    .aspectRatio(1f),
-                painter = painterResource(id = getFolderIcon(state.folderInfo.folderType)),
-                contentDescription = "상단바 아이콘",
-            )
-        }
-        Spacer(modifier = Modifier.width(16.dp))
-        Column(
-            modifier = Modifier
-                .align(Alignment.CenterVertically)
-                .fillMaxWidth(),
-        ) {
-            Text(
-                text = state.folderInfo.title,
-                style = DoraTypoTokens.Subtitle2Bold,
-            )
-            Text(
-                text = "${state.folderInfo.postCount} 게시물",
-                style = DoraTypoTokens.caption1Medium,
-            )
-        }
-    }
-}
-
-@Composable
-fun StorageDetailHeaderTabBar(
-    tabList: List<StorageDetailTab>,
-    onClickTabItem: (Int) -> Unit,
-    modifier: Modifier = Modifier,
-    selectedTabIdx: Int = 0,
-) {
-    Column {
-        Row(
-            modifier = modifier.height(48.dp).fillMaxWidth(),
-        ) {
-            tabList.forEachIndexed { index, tabItem ->
-                val isSelected = index == selectedTabIdx
-                Column(
-                    modifier = Modifier
-                        .clickable { onClickTabItem(index) }
-                        .padding(vertical = 9.5.dp),
-                ) {
-                    Text(
-                        modifier = Modifier.padding(horizontal = 24.dp),
-                        text = stringResource(id = tabItem.tabTitle),
-                        style = DoraTypoTokens.caption2Medium,
-                        color = if (isSelected) DoraColorTokens.G9 else DoraColorTokens.G4,
-                    )
-                    Spacer(modifier = Modifier.height(4.dp))
-                    if (isSelected) {
-                        Canvas(
-                            Modifier
-                                .size(3.dp)
-                                .align(Alignment.CenterHorizontally),
-                        ) {
-                            drawCircle(color = Color.Black)
-                        }
-                    }
-                }
-                if (index == 0) {
-                    VerticalDivider(
-                        modifier = Modifier.padding(top = 14.dp, bottom = 22.dp),
-                        color = DoraColorTokens.G2,
-                    )
-                }
-            }
-        }
-        HorizontalDivider(
+        DoraChips(
             modifier = Modifier.fillMaxWidth(),
-            color = DoraColorTokens.G2,
+            chipList = chipList,
+            selectedIndex = selectedTabIdx,
+            onClickChip = { onClickTabItem(it) },
         )
     }
 }
@@ -200,16 +42,14 @@ fun StorageDetailHeaderTabBar(
 @Composable
 fun StorageDetailTopBarByFolderType(
     state: StorageDetailState,
-    isCollapsed: Boolean,
     onClickActionIcon: () -> Unit = {},
     onClickBackIcon: () -> Unit,
 ) {
-    val title = if (isCollapsed) state.folderInfo.title else ""
     when (state.folderInfo.folderType) {
         FolderType.CUSTOM -> {
             DoraTopBar.BackWithActionIconTopBar(
                 modifier = Modifier.fillMaxWidth(),
-                title = title,
+                title = state.folderInfo.title,
                 isTitleCenter = true,
                 actionIcon = coreR.drawable.ic_more_black,
                 onClickBackIcon = onClickBackIcon,
@@ -220,7 +60,7 @@ fun StorageDetailTopBarByFolderType(
         else -> {
             DoraTopBar.BackNavigationTopBar(
                 modifier = Modifier.fillMaxWidth(),
-                title = title,
+                title = state.folderInfo.title,
                 isTitleCenter = true,
                 onClickBackIcon = onClickBackIcon,
                 isShowBottomDivider = false,
@@ -232,9 +72,12 @@ fun StorageDetailTopBarByFolderType(
 @Preview
 @Composable
 fun PreviewStorageDetailCollapsingTopBar() {
-    StorageDetailHeaderTabBar(
-        tabList = StorageDetailState.getDefaultTabTitleList(),
+    StorageDetailHeader(
+        state = StorageDetailState(),
+        chipList = StorageDetailState.getDefaultChipList(),
         selectedTabIdx = 0,
         onClickTabItem = {},
+        onClickActionIcon = {},
+        onClickBackIcon = {},
     )
 }

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailList.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/StorageDetailList.kt
@@ -49,9 +49,6 @@ fun StorageDetailList(
     state: StorageDetailState,
     modifier: Modifier = Modifier,
     contentPadding: PaddingValues = PaddingValues(),
-    onClickBackIcon: () -> Unit,
-    onClickTabItem: (Int) -> Unit,
-    onClickActionIcon: () -> Unit,
     onClickMoreButton: (String) -> Unit,
     onClickBookMarkButton: (FeedUiModel.FeedCardUiModel, Boolean, Int) -> Unit,
     onClickPostItem: (FeedUiModel.FeedCardUiModel) -> Unit,
@@ -60,18 +57,9 @@ fun StorageDetailList(
     val isLoading = linksPagingList.loadState.refresh is LoadState.Loading
     if (linksPagingList.itemCount == 0) {
         Box {
-            Column {
-                StorageDetailExpandedHeader(
-                    state = state,
-                    onClickBackIcon = onClickBackIcon,
-                    onClickTabItem = onClickTabItem,
-                    onClickActionIcon = onClickActionIcon,
-                )
-                if (!isLoading) {
-                    StorageDetailEmpty(modifier = modifier)
-                }
-            }
-            if (isLoading) {
+            if (!isLoading) {
+                StorageDetailEmpty(modifier = modifier)
+            } else {
                 Box(
                     modifier = Modifier
                         .fillMaxSize()
@@ -93,14 +81,6 @@ fun StorageDetailList(
                 contentPadding = contentPadding,
                 modifier = modifier,
             ) {
-                item {
-                    StorageDetailExpandedHeader(
-                        state = state,
-                        onClickBackIcon = onClickBackIcon,
-                        onClickTabItem = onClickTabItem,
-                        onClickActionIcon = onClickActionIcon,
-                    )
-                }
                 if (!isLoading) {
                     item {
                         SortButtonRow(
@@ -156,51 +136,56 @@ fun SortButtonRow(
     isLatestSort: Boolean = false,
     onClickSortedIcon: (StorageDetailSort) -> Unit = {},
 ) {
-    Row(
-        modifier = modifier
-            .padding(horizontal = 20.dp, vertical = 10.dp)
-            .fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-        horizontalArrangement = Arrangement.SpaceBetween,
+    Column(
+        modifier = modifier.fillMaxWidth(),
     ) {
-        Text(
-            text = stringResource(coreR.string.storage_detail_post_count, postCount),
-            style = DoraTypoTokens.SMedium,
-            color = DoraColorTokens.G6,
-        )
         Row(
             modifier = Modifier
-                .background(color = DoraColorTokens.White),
-            horizontalArrangement = Arrangement.spacedBy(16.dp),
+                .padding(horizontal = 20.dp, vertical = 10.dp)
+                .fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.SpaceBetween,
         ) {
-            items.forEachIndexed { index, item ->
-                Row(
-                    modifier =
-                    Modifier
-                        .align(Alignment.CenterVertically)
-                        .background(color = DoraColorTokens.White)
-                        .clickable { onClickSortedIcon(item) },
-                ) {
-                    val icon = when (item) {
-                        StorageDetailSort.ASC -> if (isLatestSort) coreR.drawable.ic_arrow_down_active else coreR.drawable.ic_arrow_down_disabled
-                        StorageDetailSort.DESC -> if (isLatestSort) coreR.drawable.ic_arrow_up_disabled else coreR.drawable.ic_arrow_up_active
+            Text(
+                text = stringResource(coreR.string.storage_detail_post_count, postCount),
+                style = DoraTypoTokens.SMedium,
+                color = DoraColorTokens.G6,
+            )
+            Row(
+                modifier = Modifier
+                    .background(color = DoraColorTokens.White),
+                horizontalArrangement = Arrangement.spacedBy(16.dp),
+            ) {
+                items.forEachIndexed { index, item ->
+                    Row(
+                        modifier =
+                        Modifier
+                            .align(Alignment.CenterVertically)
+                            .background(color = DoraColorTokens.White)
+                            .clickable { onClickSortedIcon(item) },
+                    ) {
+                        val icon = when (item) {
+                            StorageDetailSort.ASC -> if (isLatestSort) coreR.drawable.ic_arrow_down_active else coreR.drawable.ic_arrow_down_disabled
+                            StorageDetailSort.DESC -> if (isLatestSort) coreR.drawable.ic_arrow_up_disabled else coreR.drawable.ic_arrow_up_active
+                        }
+                        Image(
+                            modifier = Modifier.size(24.dp),
+                            painter = painterResource(id = icon),
+                            contentDescription = stringResource(id = item.btnName),
+                        )
+                        Spacer(modifier = Modifier.width(2.dp))
+                        Text(
+                            modifier = Modifier.align(Alignment.CenterVertically),
+                            text = stringResource(id = item.btnName),
+                            textAlign = TextAlign.Center,
+                            color = Color.Black,
+                            style = DoraTypoTokens.SMedium,
+                        )
                     }
-                    Image(
-                        modifier = Modifier.size(24.dp),
-                        painter = painterResource(id = icon),
-                        contentDescription = stringResource(id = item.btnName),
-                    )
-                    Spacer(modifier = Modifier.width(2.dp))
-                    Text(
-                        modifier = Modifier.align(Alignment.CenterVertically),
-                        text = stringResource(id = item.btnName),
-                        textAlign = TextAlign.Center,
-                        color = Color.Black,
-                        style = DoraTypoTokens.SMedium,
-                    )
                 }
             }
         }
+        DoraDivider()
     }
 }
 

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/StorageDetailState.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/StorageDetailState.kt
@@ -2,6 +2,7 @@ package com.mashup.dorabangs.feature.storage.storagedetail.model
 
 import androidx.annotation.StringRes
 import com.mashup.dorabangs.core.designsystem.R
+import com.mashup.dorabangs.core.designsystem.component.chips.FeedUiModel
 import com.mashup.dorabangs.core.designsystem.component.toast.ToastStyle
 import com.mashup.dorabangs.domain.model.Folder
 import com.mashup.dorabangs.domain.model.FolderType
@@ -24,11 +25,20 @@ data class StorageDetailState(
     val isUnreadChecked: Boolean = false,
 ) {
     companion object {
-        fun getDefaultTabTitleList() = listOf(StorageDetailTab.ALL, StorageDetailTab.UNREAD)
+        fun getDefaultChipList() = listOf(
+            FeedUiModel.DoraChipUiModel(
+                title = StorageDetailTab.ALL.tabTitle,
+                icon = null,
+            ),
+            FeedUiModel.DoraChipUiModel(
+                title = StorageDetailTab.UNREAD.tabTitle,
+                icon = null,
+            ),
+        )
     }
 }
 data class TabInfo(
-    val tabTitleList: List<StorageDetailTab> = StorageDetailState.getDefaultTabTitleList(),
+    val tabTitleList: List<FeedUiModel.DoraChipUiModel> = StorageDetailState.getDefaultChipList(),
     val selectedTabIdx: Int = 0,
 )
 

--- a/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/StorageDetailTab.kt
+++ b/feature/storage/src/main/java/com/mashup/dorabangs/feature/storage/storagedetail/model/StorageDetailTab.kt
@@ -1,8 +1,6 @@
 package com.mashup.dorabangs.feature.storage.storagedetail.model
 
-import com.mashup.dorabangs.feature.storage.R
-
-enum class StorageDetailTab(val tabTitle: Int) {
-    ALL(R.string.storage_detail_tab_all),
-    UNREAD(R.string.storage_detail_tab_unread),
+enum class StorageDetailTab(val tabTitle: String) {
+    ALL("전체"),
+    UNREAD("읽지 않은"),
 }


### PR DESCRIPTION
## 개요
> 이슈 링크 혹은 PR 내용 요약
- 보관함 상세 탭 디자인 수정

## 작업 내용
> 실제 작업 내용
- 보관함 상세 탭 디자인 변경이 안되어있어서 했습니다~~

## 시연 화면 (option)
> 실행 스크린샷 혹은 영상 첨부

|기능A 구현|
|:---|
|<img width="296" alt="스크린샷 2024-09-27 오후 1 23 38" src="https://github.com/user-attachments/assets/7c59a39b-f393-46d2-bbdf-a0bb04ad4c41">|

## To Reviers
> 리뷰어들에게 전할 말
- 곧 자유다~

## Close
close #